### PR TITLE
remove legacy options

### DIFF
--- a/api/backtest.resolver.go
+++ b/api/backtest.resolver.go
@@ -28,12 +28,10 @@ type BacktestRequest struct {
 	BacktestEnd          string `json:"backtestEnd"`
 	SamplingIntervalUnit string `json:"samplingIntervalUnit"`
 
-	AssetSelectionMode string  `json:"assetSelectionMode"`
-	StartCash          float64 `json:"startCash"`
+	StartCash float64 `json:"startCash"`
 
-	AnchorPortfolioQuantities map[string]float64 `json:"anchorPortfolio"`
-	NumSymbols                int                `json:"numSymbols"`
-	UserID                    *string            `json:"userID"`
+	NumSymbols int     `json:"numSymbols"`
+	UserID     *string `json:"userID"`
 }
 
 type BacktestResponse struct {
@@ -144,15 +142,13 @@ func saveUserStrategy(
 	requestId *uuid.UUID,
 ) error {
 	type strategyInput struct {
-		FactorName                string             `json:"factorName"`
-		FactorExpression          string             `json:"factorExpression"`
-		BacktestStart             string             `json:"backtestStart"`
-		BacktestEnd               string             `json:"backtestEnd"`
-		RebalanceInterval         string             `json:"rebalanceInterval"`
-		AssetSelectionMode        string             `json:"assetSelectionMode"`
-		StartCash                 float64            `json:"startCash"`
-		AnchorPortfolioQuantities map[string]float64 `json:"anchorPortfolio"`
-		NumSymbols                int                `json:"numSymbols,omitempty"`
+		FactorName        string  `json:"factorName"`
+		FactorExpression  string  `json:"factorExpression"`
+		BacktestStart     string  `json:"backtestStart"`
+		BacktestEnd       string  `json:"backtestEnd"`
+		RebalanceInterval string  `json:"rebalanceInterval"`
+		StartCash         float64 `json:"startCash"`
+		NumSymbols        int     `json:"numSymbols,omitempty"`
 	}
 
 	regex := regexp.MustCompile(`\s+`)
@@ -161,18 +157,11 @@ func saveUserStrategy(
 	// keep only selected fields bc we don't care about including
 	// factor name and cash in hash
 	si := &strategyInput{
-		FactorExpression:   cleanedExpression,
-		BacktestStart:      requestBody.BacktestStart,
-		BacktestEnd:        requestBody.BacktestEnd,
-		RebalanceInterval:  requestBody.SamplingIntervalUnit,
-		AssetSelectionMode: requestBody.AssetSelectionMode,
-		// keep history happy by finding prev values
-		AnchorPortfolioQuantities: map[string]float64{
-			"AAPL":  10,
-			"MSFT":  10,
-			"GOOGL": 8,
-		},
-		NumSymbols: requestBody.NumSymbols,
+		FactorExpression:  cleanedExpression,
+		BacktestStart:     requestBody.BacktestStart,
+		BacktestEnd:       requestBody.BacktestEnd,
+		RebalanceInterval: requestBody.SamplingIntervalUnit,
+		NumSymbols:        requestBody.NumSymbols,
 	}
 	siBytes, err := json.Marshal(si)
 	if err != nil {

--- a/integration-tests/idk_test.go
+++ b/integration-tests/idk_test.go
@@ -179,8 +179,8 @@ func Test_backtestFlow(t *testing.T) {
 		BacktestEnd:          "2020-12-31",
 		SamplingIntervalUnit: "weekly",
 		StartCash:            10000,
-
-		UserID: &userID,
+		NumSymbols:           3,
+		UserID:               &userID,
 	}
 	response := api.BacktestResponse{}
 	err = hitEndpoint("backtest", http.MethodPost, request, &response)

--- a/integration-tests/idk_test.go
+++ b/integration-tests/idk_test.go
@@ -178,7 +178,6 @@ func Test_backtestFlow(t *testing.T) {
 		BacktestStart:        "2020-01-10",
 		BacktestEnd:          "2020-12-31",
 		SamplingIntervalUnit: "weekly",
-		AssetSelectionMode:   "NUM_SYMBOLS",
 		StartCash:            10000,
 
 		UserID: &userID,

--- a/integration-tests/idk_test.go
+++ b/integration-tests/idk_test.go
@@ -165,17 +165,14 @@ func Test_backtestFlow(t *testing.T) {
 	err = tx.Commit()
 	require.NoError(t, err)
 
-	numSymbols := 3
 	userID := uuid.NewString()
 	startTime := time.Now()
 	request := api.BacktestRequest{
 		FactorOptions: struct {
-			Expression string  "json:\"expression\""
-			Intensity  float64 "json:\"intensity\""
-			Name       string  "json:\"name\""
+			Expression string "json:\"expression\""
+			Name       string "json:\"name\""
 		}{
 			Expression: "pricePercentChange(\n  nDaysAgo(7),\n  currentDate\n) ",
-			Intensity:  0.75,
 			Name:       "7_day_momentum",
 		},
 		BacktestStart:        "2020-01-10",
@@ -183,13 +180,8 @@ func Test_backtestFlow(t *testing.T) {
 		SamplingIntervalUnit: "weekly",
 		AssetSelectionMode:   "NUM_SYMBOLS",
 		StartCash:            10000,
-		AnchorPortfolioQuantities: map[string]float64{
-			"AAPL":  10,
-			"MSFT":  10,
-			"GOOGL": 8,
-		},
-		NumSymbols: &numSymbols,
-		UserID:     &userID,
+
+		UserID: &userID,
 	}
 	response := api.BacktestResponse{}
 	err = hitEndpoint("backtest", http.MethodPost, request, &response)

--- a/internal/app/backtest.go
+++ b/internal/app/backtest.go
@@ -156,6 +156,9 @@ type ComputeTargetPortfolioResponse struct {
 // Computes what the portfolio should hold on a given day, given the
 // strategy (equation and universe) and value of current holdings
 func (h BacktestHandler) ComputeTargetPortfolio(in ComputeTargetPortfolioInput) (*ComputeTargetPortfolioResponse, error) {
+	if in.TargetNumTickers < 3 {
+		return nil, fmt.Errorf("insufficient tickers: at least 3 target tickers required, got %d", in.TargetNumTickers)
+	}
 	symbols := in.UniverseSymbols
 	if len(symbols) == 0 {
 		return nil, fmt.Errorf("cannot compute target portfolio with 0 asset universe")

--- a/internal/app/backtest.go
+++ b/internal/app/backtest.go
@@ -239,7 +239,6 @@ type BacktestInput struct {
 	BacktestStart     time.Time
 	BacktestEnd       time.Time
 	RebalanceInterval time.Duration
-	AssetUniverse     string
 	StartingCash      float64
 	NumTickers        int
 }
@@ -370,7 +369,7 @@ func (h BacktestHandler) Backtest(ctx context.Context, in BacktestInput) (*Backt
 		return nil, fmt.Errorf("too many backtest errors (%d %%). first %d: %v", int(100*float64(len(backtestErrors))/float64(len(tradingDays))), numErrors, backtestErrors[:numErrors])
 	}
 
-	snapshots, err := toSnapshots(out, priceCache, h.Db)
+	snapshots, err := toSnapshots(out, priceCache)
 	if err != nil {
 		return nil, fmt.Errorf("failed to compute snapshots: %w", err)
 	}
@@ -381,7 +380,7 @@ func (h BacktestHandler) Backtest(ctx context.Context, in BacktestInput) (*Backt
 	}, nil
 }
 
-func toSnapshots(result []BacktestSample, priceCache *service.PriceCache, db *sql.DB) (map[string]BacktestSnapshot, error) {
+func toSnapshots(result []BacktestSample, priceCache *service.PriceCache) (map[string]BacktestSnapshot, error) {
 	snapshots := map[string]BacktestSnapshot{}
 
 	for i, r := range result {

--- a/internal/app/backtest.go
+++ b/internal/app/backtest.go
@@ -138,13 +138,12 @@ func (h BacktestHandler) calculateFactorScores(ctx context.Context, pr *service.
 }
 
 type ComputeTargetPortfolioInput struct {
-	PriceMap        map[string]float64
-	Date            time.Time
-	PortfolioValue  float64
-	FactorIntensity float64
-	UniverseSymbols []string
-	AssetOptions    internal.AssetSelectionOptions
-	FactorScores    map[string]*float64
+	PriceMap         map[string]float64
+	Date             time.Time
+	PortfolioValue   float64
+	UniverseSymbols  []string
+	FactorScores     map[string]*float64
+	TargetNumTickers int
 }
 
 type ComputeTargetPortfolioResponse struct {
@@ -157,26 +156,16 @@ type ComputeTargetPortfolioResponse struct {
 // Computes what the portfolio should hold on a given day, given the
 // strategy (equation and universe) and value of current holdings
 func (h BacktestHandler) ComputeTargetPortfolio(in ComputeTargetPortfolioInput) (*ComputeTargetPortfolioResponse, error) {
-	symbols := []string{}
-	if in.AssetOptions.Mode == internal.AssetSelectionMode_AnchorPortfolio {
-		for symbol := range in.AssetOptions.AnchorPortfolioWeights {
-			symbols = append(symbols, symbol)
-		}
-	} else {
-		symbols = in.UniverseSymbols
-	}
-
+	symbols := in.UniverseSymbols
 	if len(symbols) == 0 {
 		return nil, fmt.Errorf("cannot compute target portfolio with 0 asset universe")
 	}
 
 	computeTargetInput := internal.CalculateTargetAssetWeightsInput{
-		Date:                  in.Date,
-		FactorScoresBySymbol:  in.FactorScores,
-		FactorIntensity:       in.FactorIntensity,
-		AssetSelectionOptions: in.AssetOptions,
+		Date:                 in.Date,
+		FactorScoresBySymbol: in.FactorScores,
+		NumTickers:           in.TargetNumTickers,
 	}
-
 	newWeights, err := internal.CalculateTargetAssetWeights(computeTargetInput)
 	if err != nil {
 		return nil, fmt.Errorf("failed to calculate target asset weights: %w", err)
@@ -187,6 +176,8 @@ func (h BacktestHandler) ComputeTargetPortfolio(in ComputeTargetPortfolioInput) 
 	targetPortfolio := &domain.Portfolio{
 		Positions: map[string]*domain.Position{},
 	}
+
+	// convert weights into quantities
 	for symbol, weight := range newWeights {
 		price, ok := in.PriceMap[symbol]
 		if !ok {
@@ -242,21 +233,15 @@ type ScnapshotAssetMetrics struct {
 	PriceChangeTilNextResampling *float64 `json:"priceChangeTilNextResampling"`
 }
 
-type FactorOptions struct {
-	Expression string
-	Intensity  float64
-	Name       string
-}
-
 type BacktestInput struct {
-	FactorOptions    FactorOptions
-	BacktestStart    time.Time
-	BacktestEnd      time.Time
-	SamplingInterval time.Duration
-	StartPortfolio   domain.Portfolio
-
-	AnchorPortfolioQuantities map[string]float64
-	AssetOptions              internal.AssetSelectionOptions
+	FactorName        string
+	FactorExpression  string
+	BacktestStart     time.Time
+	BacktestEnd       time.Time
+	RebalanceInterval time.Duration
+	AssetUniverse     string
+	StartingCash      float64
+	NumTickers        int
 }
 
 type BacktestResponse struct {
@@ -279,7 +264,7 @@ func (h BacktestHandler) Backtest(ctx context.Context, in BacktestInput) (*Backt
 	// all trading days within the selected window that we need to run a calculation on
 	// this will only contain days that we actually have data for, so if data is old, it
 	// will not include recent days
-	tradingDays, err := h.calculateRelevantTradingDays(in.BacktestStart, in.BacktestEnd, in.SamplingInterval)
+	tradingDays, err := h.calculateRelevantTradingDays(in.BacktestStart, in.BacktestEnd, in.RebalanceInterval)
 	if err != nil {
 		return nil, err
 	}
@@ -290,7 +275,7 @@ func (h BacktestHandler) Backtest(ctx context.Context, in BacktestInput) (*Backt
 			inputs = append(inputs, workInput{
 				Symbol:           symbol,
 				Date:             tradingDay,
-				FactorExpression: in.FactorOptions.Expression,
+				FactorExpression: in.FactorExpression,
 			})
 		}
 	}
@@ -311,27 +296,11 @@ func (h BacktestHandler) Backtest(ctx context.Context, in BacktestInput) (*Backt
 	fmt.Println("scores calculated in", time.Since(x).Seconds())
 	profile.Add("finished scores")
 
-	// get price on first day? consider removing
-	backtestStartPriceMap, err := h.PriceRepository.GetMany(universeSymbols, in.BacktestStart)
-	if err != nil {
-		return nil, err
+	startValue := in.StartingCash
+
+	currentPortfolio := domain.Portfolio{
+		Cash: startValue,
 	}
-
-	anchorPortfolioWeights, err := h.calculateAnchorPortfolioWeights(in.AnchorPortfolioQuantities, backtestStartPriceMap)
-	if err != nil {
-		return nil, fmt.Errorf("failed to calculate anchor portfolio weights: %w", err)
-	}
-
-	in.AssetOptions.AnchorPortfolioWeights = anchorPortfolioWeights
-
-	startValue, err := in.StartPortfolio.TotalValue(backtestStartPriceMap)
-	if err != nil {
-		return nil, fmt.Errorf("failed to compute start value: %w", err)
-	} else if startValue == 0 {
-		return nil, fmt.Errorf("cannot backtest portfolio with 0 total value")
-	}
-
-	currentPortfolio := *in.StartPortfolio.DeepCopy()
 	out := []BacktestSample{}
 
 	profile.Add("finished backtest setup")
@@ -357,13 +326,12 @@ func (h BacktestHandler) Backtest(ctx context.Context, in BacktestInput) (*Backt
 		}
 
 		computeTargetPortfolioResponse, err := h.ComputeTargetPortfolio(ComputeTargetPortfolioInput{
-			Date:            t,
-			FactorIntensity: in.FactorOptions.Intensity,
-			FactorScores:    factorScoresByDay[t],
-			AssetOptions:    in.AssetOptions,
-			PortfolioValue:  currentPortfolioValue,
-			PriceMap:        priceMap,
-			UniverseSymbols: universeSymbols,
+			Date:             t,
+			TargetNumTickers: in.NumTickers,
+			FactorScores:     factorScoresByDay[t],
+			PortfolioValue:   currentPortfolioValue,
+			PriceMap:         priceMap,
+			UniverseSymbols:  universeSymbols,
 		})
 		if err != nil {
 			// TODO figure out what to do here. should

--- a/internal/weighting.go
+++ b/internal/weighting.go
@@ -32,10 +32,6 @@ type CalculateTargetAssetWeightsInput struct {
 // use a factor strategy and determine what the weight
 // of each asset should be on given date
 func CalculateTargetAssetWeights(in CalculateTargetAssetWeightsInput) (map[string]float64, error) {
-	// todo - validate rest of input
-	// keys(FactorScoresBySymbol) == keys(Benchmark)
-	// non-nil maps, valid date
-
 	newWeights, err := calculateWeightsViaNumTickers(
 		in.NumTickers,
 		in.FactorScoresBySymbol,

--- a/internal/weighting.go
+++ b/internal/weighting.go
@@ -1,7 +1,6 @@
 package internal
 
 import (
-	"database/sql"
 	"fmt"
 	"math"
 	"sort"
@@ -16,146 +15,33 @@ import (
 // factor scores and (maybe) benchmark
 
 /**
-
-1. anchor portfolio
-pick a sample portfolio. the factors will tilt the portfolio so that all of the original assets are still present. it will also tilt relative to the original weightings. this is a good way to see, "this is my portfolio, how would slightly adding a factor help"
-
-2. num tickers
-for every asset in the universe, compute the factor score. take the top N+1 assets. take the z-score of each (where the population is the top N+1 assets) and scale the scores between [0, 1]. We take N+1 because the lowest element will have scaled value of 0. assign each asset the weighted average of the scaled value.
-
-3. top N-tile
-for every asset in the universe, compute the factor score. take range of socres and figure out what the top N-tile of the scores is; specifically how many symbols it includes (picture a number line with all factor scores). make that value the num tickers for the iteration and then calculate via num tickers.
-
-
 the biggest question is how to manage un-normalized factors. theoretically the factors can be anything. for example, if returns are 5%, 10% and 20% for two assets and i use (7 day rolling avg) vs  5*(7 day rolling avg), i would get [5, 10, 20] and [25, 50, 100].
 
 A: score range: dist([5, 20]) = 15. 15/4 (what is a quarter of the distance) = 8.25. so the final quarter would be 20-8.25 = 12.25. so len(scores > 12.25) = 1
 B: dist([25, 50]) = 75. 75/4 = 18.75. 100-18.75 = 71.25. len(scores > 71.25) = 1
 
 in this case it's the same but be careful of weird equations where it might not be. i think if all factors are scaled the same way then it's fine.
-
 */
 
-type AssetSelectionMode string
-
-const (
-	// always have N tickers in portfolio
-	AssetSelectionMode_NumTickers AssetSelectionMode = "NUM_SYMBOLS"
-	// use start portfolio as anchor
-	AssetSelectionMode_AnchorPortfolio AssetSelectionMode = "ANCHOR_PORTFOLIO"
-	// not even top X assets - only keep the highest
-	// assets of the factor scores. AKA variable num tickers
-	// basically sum all the factor scores
-	AssetSelectionMode_TopQuartile AssetSelectionMode = "TOP_QUARTILE"
-)
-
-func NewAssetSelectionMode(s string) (*AssetSelectionMode, error) {
-	m := map[string]AssetSelectionMode{
-		"NUM_SYMBOLS":      AssetSelectionMode_NumTickers,
-		"ANCHOR_PORTFOLIO": AssetSelectionMode_AnchorPortfolio,
-		"TOP_QUARTILE":     AssetSelectionMode_TopQuartile,
-	}
-	for k, v := range m {
-		if strings.EqualFold(
-			strings.ReplaceAll(k, "_", ""),
-			strings.ReplaceAll(s, "_", ""),
-		) {
-			return &v, nil
-		}
-	}
-	return nil, fmt.Errorf("could not convert '%s' to known asset selection mode", s)
-}
-
-type AssetSelectionOptions struct {
-	NumTickers             *int
-	AnchorPortfolioWeights map[string]float64
-	Mode                   AssetSelectionMode
-}
-
-func (aso AssetSelectionOptions) Valid() error {
-	// TODO - add more checks
-	prefix := fmt.Sprintf("asset selection mode is %s", aso.Mode)
-	switch aso.Mode {
-	case AssetSelectionMode_NumTickers:
-		if aso.NumTickers == nil {
-			return fmt.Errorf(prefix + " and num tickers is nil")
-		}
-		if *aso.NumTickers == 0 {
-			return fmt.Errorf(prefix + " and num tickers is 0")
-		}
-	case AssetSelectionMode_AnchorPortfolio:
-		if aso.AnchorPortfolioWeights == nil {
-			return fmt.Errorf(prefix + " and anchor portfolio is nil")
-		}
-		if len(aso.AnchorPortfolioWeights) < 2 {
-			return fmt.Errorf(prefix + " and anchor portfolio has < 2 assets")
-		}
-		sum := 0.0
-		for _, a := range aso.AnchorPortfolioWeights {
-			sum += a
-		}
-		if math.Abs(1-sum) > 0.0001 {
-			return fmt.Errorf("sum of anchor portfolio weights sums to %f", sum)
-		}
-	case AssetSelectionMode_TopQuartile:
-		return nil
-	default:
-		return fmt.Errorf("unknown asset selection mode '%s'", aso.Mode)
-	}
-	return nil
-}
-
 type CalculateTargetAssetWeightsInput struct {
-	Tx                    *sql.Tx
-	Date                  time.Time
-	FactorScoresBySymbol  map[string]*float64
-	FactorIntensity       float64
-	AssetSelectionOptions AssetSelectionOptions
+	Date                 time.Time
+	FactorScoresBySymbol map[string]*float64
+	NumTickers           int
 }
 
 // use a factor strategy and determine what the weight
 // of each asset should be on given date
 func CalculateTargetAssetWeights(in CalculateTargetAssetWeightsInput) (map[string]float64, error) {
-	if in.FactorIntensity <= 0 || in.FactorIntensity > 1 {
-		return nil, fmt.Errorf("factor intensity must be between (0, 1], got %f", in.FactorIntensity)
-	}
 	// todo - validate rest of input
 	// keys(FactorScoresBySymbol) == keys(Benchmark)
 	// non-nil maps, valid date
 
-	err := in.AssetSelectionOptions.Valid()
+	newWeights, err := calculateWeightsViaNumTickers(
+		in.NumTickers,
+		in.FactorScoresBySymbol,
+	)
 	if err != nil {
-		return nil, fmt.Errorf("failed to verify asset selection options: %w", err)
-	}
-
-	var newWeights map[string]float64
-
-	switch in.AssetSelectionOptions.Mode {
-	case AssetSelectionMode_NumTickers:
-		newWeights, err = calculateWeightsViaNumTickers(
-			*in.AssetSelectionOptions.NumTickers,
-			in.FactorScoresBySymbol,
-		)
-	case AssetSelectionMode_AnchorPortfolio:
-		newScoreMap := map[string]float64{}
-		for k, v := range in.FactorScoresBySymbol {
-			if v == nil {
-				return nil, fmt.Errorf("nil score for %s", k)
-			}
-			newScoreMap[k] = *v
-		}
-		newWeights, err = calculateWeightsRelativeToAnchor(
-			in.AssetSelectionOptions.AnchorPortfolioWeights,
-			newScoreMap,
-			in.FactorIntensity,
-		)
-	case AssetSelectionMode_TopQuartile:
-		newWeights = map[string]float64{}
-	default:
-		return nil, fmt.Errorf("unknown asset selection '%s'", in.AssetSelectionOptions.Mode)
-	}
-	if err != nil {
-		return nil, fmt.Errorf("failed to calculate weights for mode %s: %w", in.AssetSelectionOptions.Mode, err)
+		return nil, fmt.Errorf("failed to calculate weights: %w", err)
 	}
 
 	// validate new weights add to 100


### PR DESCRIPTION
previously supported anchor portfolios as an option, and made intensity user-configurable. considering we don't want to support this, it's easier to deprecate the field and simplify the interface.