### PR TITLE
disclude alpaca prices from non-local

### DIFF
--- a/cmd/util.go
+++ b/cmd/util.go
@@ -11,6 +11,8 @@ import (
 	"factorbacktest/internal/util"
 	"fmt"
 	"log"
+	"os"
+	"strings"
 
 	_ "github.com/lib/pq"
 )
@@ -65,7 +67,12 @@ func InitializeDependencies() (*api.ApiHandler, error) {
 		alpacaRepository = NewMockAlpacaRepository(alpacaRepository, tradeOrderRepository, tickerRepository)
 	}
 
-	priceService := l1_service.NewPriceService(dbConn, priceRepository, alpacaRepository)
+	var priceServiceAlpacaRepository repository.AlpacaRepository = nil
+	if strings.EqualFold(os.Getenv("ALPHA_ENV"), "dev") {
+		priceServiceAlpacaRepository = alpacaRepository
+	}
+
+	priceService := l1_service.NewPriceService(dbConn, priceRepository, priceServiceAlpacaRepository)
 	assetUniverseRepository := repository.NewAssetUniverseRepository(dbConn)
 	factorExpressionService := l2_service.NewFactorExpressionService(dbConn, factorMetricsHandler, priceService, factorScoreRepository)
 	backtestHandler := l3_service.BacktestHandler{

--- a/internal/service/l1/price.service.go
+++ b/internal/service/l1/price.service.go
@@ -280,26 +280,28 @@ func (h priceServiceHandler) LoadPriceCache(ctx context.Context, inputs []LoadPr
 	fillPriceCacheGaps(inputs, cache)
 	endNewSpan()
 
-	latestPrices, err := h.AlpacaRepository.GetLatestPricesWithTs(symbols)
-	if err != nil {
-		return nil, err
-	}
-	for symbol, price := range latestPrices {
-		if len(tradingDays) == 0 || price.Date.Format(time.DateOnly) > tradingDays[len(tradingDays)-1].Format(time.DateOnly) {
-			// might wanna set time to 0
-			zeroedDate := time.Date(
-				price.Date.Year(),
-				price.Date.Month(),
-				price.Date.Day(),
-				0,
-				0,
-				0,
-				0,
-				time.UTC,
-			)
-			tradingDays = append(tradingDays, zeroedDate)
+	if h.AlpacaRepository != nil {
+		latestPrices, err := h.AlpacaRepository.GetLatestPricesWithTs(symbols)
+		if err != nil {
+			return nil, err
 		}
-		cache[symbol][price.Date.Format(time.DateOnly)] = price.Price.InexactFloat64()
+		for symbol, price := range latestPrices {
+			if len(tradingDays) == 0 || price.Date.Format(time.DateOnly) > tradingDays[len(tradingDays)-1].Format(time.DateOnly) {
+				// might wanna set time to 0
+				zeroedDate := time.Date(
+					price.Date.Year(),
+					price.Date.Month(),
+					price.Date.Day(),
+					0,
+					0,
+					0,
+					0,
+					time.UTC,
+				)
+				tradingDays = append(tradingDays, zeroedDate)
+			}
+			cache[symbol][price.Date.Format(time.DateOnly)] = price.Price.InexactFloat64()
+		}
 	}
 
 	_, endNewSpan = newProfile.StartNewSpan("populating stdev cache")


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved error handling in the price retrieval process to prevent potential runtime errors when the AlpacaRepository is uninitialized.

- **New Features**
  - Enhanced configurability of the price service initialization based on the development environment, allowing for more flexible setups.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->