### PR TITLE
Fix percentChange formula and Sharpe ratio calculation

### DIFF
--- a/internal/calculator/factor_expression.service.go
+++ b/internal/calculator/factor_expression.service.go
@@ -680,7 +680,7 @@ func (h factorMetricsHandler) PricePercentChange(pr *data.PriceCache, symbol str
 }
 
 func percentChange(end, start float64) float64 {
-	return ((end - start) / end) * 100
+	return ((end - start) / start) * 100
 }
 
 func (h factorMetricsHandler) AnnualizedStdevOfDailyReturns(ctx context.Context, pr *data.PriceCache, symbol string, start, end time.Time) (float64, error) {

--- a/internal/calculator/metrics.service.go
+++ b/internal/calculator/metrics.service.go
@@ -54,7 +54,7 @@ func CalculateMetrics(backtestResults []BacktestResult, relevantTradingDays []ti
 	numYears := numHours / (365 * 24)
 	annualizedReturn := math.Pow((endValue/startValue), 1/numYears) - 1
 
-	sharpeRatio := annualizedReturn / stdev
+	sharpeRatio := annualizedReturn / annualizedStdev
 
 	return &CalculateMetricsResult{
 		AnnualizedStdev:  annualizedStdev,

--- a/internal/calculator/percent_change_test.go
+++ b/internal/calculator/percent_change_test.go
@@ -1,0 +1,55 @@
+package calculator
+
+import (
+	"math"
+	"testing"
+)
+
+func Test_percentChange(t *testing.T) {
+	tests := []struct {
+		name     string
+		end      float64
+		start    float64
+		expected float64
+	}{
+		{
+			name:     "simple increase",
+			end:      110,
+			start:    100,
+			expected: 10.0,
+		},
+		{
+			name:     "simple decrease",
+			end:      90,
+			start:    100,
+			expected: -10.0,
+		},
+		{
+			name:     "no change",
+			end:      100,
+			start:    100,
+			expected: 0.0,
+		},
+		{
+			name:     "double",
+			end:      200,
+			start:    100,
+			expected: 100.0,
+		},
+		{
+			name:     "50 percent drop",
+			end:      50,
+			start:    100,
+			expected: -50.0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := percentChange(tt.end, tt.start)
+			if math.Abs(got-tt.expected) > 0.0001 {
+				t.Errorf("percentChange(%v, %v) = %v, want %v", tt.end, tt.start, got, tt.expected)
+			}
+		})
+	}
+}

--- a/internal/data/percent_change_test.go
+++ b/internal/data/percent_change_test.go
@@ -1,0 +1,49 @@
+package data
+
+import (
+	"math"
+	"testing"
+)
+
+func Test_percentChange(t *testing.T) {
+	tests := []struct {
+		name     string
+		end      float64
+		start    float64
+		expected float64
+	}{
+		{
+			name:     "simple increase",
+			end:      110,
+			start:    100,
+			expected: 10.0,
+		},
+		{
+			name:     "simple decrease",
+			end:      90,
+			start:    100,
+			expected: -10.0,
+		},
+		{
+			name:     "no change",
+			end:      100,
+			start:    100,
+			expected: 0.0,
+		},
+		{
+			name:     "double",
+			end:      200,
+			start:    100,
+			expected: 100.0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := percentChange(tt.end, tt.start)
+			if math.Abs(got-tt.expected) > 0.0001 {
+				t.Errorf("percentChange(%v, %v) = %v, want %v", tt.end, tt.start, got, tt.expected)
+			}
+		})
+	}
+}

--- a/internal/data/price.service.go
+++ b/internal/data/price.service.go
@@ -97,7 +97,7 @@ func (pr *PriceCache) Get(symbol string, date time.Time) (float64, error) {
 }
 
 func percentChange(end, start float64) float64 {
-	return ((end - start) / end) * 100
+	return ((end - start) / start) * 100
 }
 
 func stdevsFromPriceMap(minMaxMap map[string]*minMax, priceCache map[string]map[string]float64, stdevInputs []LoadStdevCacheInput, tradingDays []time.Time) (*stdevCache, error) {


### PR DESCRIPTION
## Summary

Two bugs in the financial metrics calculations:

### 1. `percentChange` divides by wrong value (both packages)

The formula was:
```go
return ((end - start) / end) * 100
```

This divides by the **end** price, but percent change should be relative to the **start** price:
```go
return ((end - start) / start) * 100
```

**Example:** A stock going from $100 → $110 should be +10%, but the old formula computed `(110-100)/110 = 9.09%`. This affected factor score calculations (via `pricePercentChange`) and the stdev cache (daily return calculations in `price.service.go`).

### 2. Sharpe ratio uses non-annualized stdev

The Sharpe ratio was computed as:
```go
sharpeRatio := annualizedReturn / stdev  // daily stdev
```

Since the numerator is annualized, the denominator should be too:
```go
sharpeRatio := annualizedReturn / annualizedStdev
```

The `annualizedStdev` was already being calculated (`stdev * sqrt(252)`) and returned in the result struct — it just wasn't being used for Sharpe.

### Tests added
- Unit tests for `percentChange` in both `internal/calculator` and `internal/data` packages

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected percentage change calculation to use starting value as the reference point instead of ending value, affecting all price change metrics
  * Fixed Sharpe ratio calculation to properly annualize both return and volatility components

* **Tests**
  * Added test suites for percentage change calculations with multiple scenarios

<!-- end of auto-generated comment: release notes by coderabbit.ai -->