### PR TITLE
Capture Alpaca errors in trade_order.notes + add POST /updateOrders endpoint

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -118,7 +118,7 @@ func (m ApiHandler) InitializeRouterEngine(ctx context.Context) *gin.Engine {
 	engine.GET("/publishedStrategies", m.getPublishedStrategies)
 
 	engine.POST("/rebalance", m.rebalance)
-	engine.POST("/updateOrders", m.updateOrders)
+	engine.POST("/updateOrders", m.requireAuthenticatedUser, m.updateOrders)
 	engine.POST("/sendSavedStrategySummaryEmails", m.sendSavedStrategySummaryEmails)
 
 	return engine
@@ -306,6 +306,14 @@ func (m ApiHandler) getGoogleAuthMiddleware(c *gin.Context) {
 	)
 	c.Set(logger.ContextKey, lg)
 
+	c.Next()
+}
+
+func (m ApiHandler) requireAuthenticatedUser(c *gin.Context) {
+	if _, ok := c.Get("userAccountID"); !ok {
+		returnErrorJsonCode(fmt.Errorf("authentication required"), c, 401)
+		return
+	}
 	c.Next()
 }
 

--- a/api/api.go
+++ b/api/api.go
@@ -118,6 +118,7 @@ func (m ApiHandler) InitializeRouterEngine(ctx context.Context) *gin.Engine {
 	engine.GET("/publishedStrategies", m.getPublishedStrategies)
 
 	engine.POST("/rebalance", m.rebalance)
+	engine.POST("/updateOrders", m.updateOrders)
 	engine.POST("/sendSavedStrategySummaryEmails", m.sendSavedStrategySummaryEmails)
 
 	return engine

--- a/api/api.go
+++ b/api/api.go
@@ -118,7 +118,7 @@ func (m ApiHandler) InitializeRouterEngine(ctx context.Context) *gin.Engine {
 	engine.GET("/publishedStrategies", m.getPublishedStrategies)
 
 	engine.POST("/rebalance", m.rebalance)
-	engine.POST("/updateOrders", m.requireAuthenticatedUser, m.updateOrders)
+	engine.POST("/updateOrders", m.updateOrders)
 	engine.POST("/sendSavedStrategySummaryEmails", m.sendSavedStrategySummaryEmails)
 
 	return engine

--- a/api/update_orders.resolver.go
+++ b/api/update_orders.resolver.go
@@ -5,7 +5,7 @@ import (
 )
 
 func (m ApiHandler) updateOrders(c *gin.Context) {
-	err := m.TradingService.UpdateAllPendingOrders(c)
+	err := m.TradingService.UpdateAllPendingOrders(c.Request.Context())
 	if err != nil {
 		returnErrorJson(err, c)
 		return

--- a/api/update_orders.resolver.go
+++ b/api/update_orders.resolver.go
@@ -1,0 +1,14 @@
+package api
+
+import (
+	"github.com/gin-gonic/gin"
+)
+
+func (m ApiHandler) updateOrders(c *gin.Context) {
+	err := m.TradingService.UpdateAllPendingOrders(c)
+	if err != nil {
+		returnErrorJson(err, c)
+		return
+	}
+	c.JSON(200, gin.H{"success": "true"})
+}

--- a/internal/service/trade.service.go
+++ b/internal/service/trade.service.go
@@ -110,14 +110,21 @@ func (h tradeServiceHandler) placeOrder(
 	})
 	if err != nil {
 		// persist the error message in the trade order notes for debugging
-		errMsg := fmt.Sprintf("order for trade request %s %s %s failed: %s", alpacaSide, symbol, quantity.String(), err.Error())
-		h.TradeOrderRepository.Update(nil,
+		prefix := ""
+		if insertedOrder.Notes != nil && *insertedOrder.Notes != "" {
+			prefix = *insertedOrder.Notes + " | "
+		}
+		errMsg := fmt.Sprintf("%sorder for trade request %s %s %s failed: %s", prefix, alpacaSide, symbol, quantity.String(), err.Error())
+		_, noteErr := h.TradeOrderRepository.Update(nil,
 			insertedOrder.TradeOrderID,
 			model.TradeOrder{
 				Notes: &errMsg,
 			}, postgres.ColumnList{
 				table.TradeOrder.Notes,
 			})
+		if noteErr != nil {
+			return nil, fmt.Errorf("failed to execute order for trade order %s: %w (also failed to persist notes: %v)", insertedOrder.TradeOrderID, err, noteErr)
+		}
 		return nil, fmt.Errorf("failed to execute order for trade order %s: %w", insertedOrder.TradeOrderID, err)
 	}
 

--- a/internal/service/trade.service.go
+++ b/internal/service/trade.service.go
@@ -109,6 +109,15 @@ func (h tradeServiceHandler) placeOrder(
 		LimitPrice:   &limit,
 	})
 	if err != nil {
+		// persist the error message in the trade order notes for debugging
+		errMsg := fmt.Sprintf("order for trade request %s %s %s failed: %s", alpacaSide, symbol, quantity.String(), err.Error())
+		h.TradeOrderRepository.Update(nil,
+			insertedOrder.TradeOrderID,
+			model.TradeOrder{
+				Notes: &errMsg,
+			}, postgres.ColumnList{
+				table.TradeOrder.Notes,
+			})
 		return nil, fmt.Errorf("failed to execute order for trade order %s: %w", insertedOrder.TradeOrderID, err)
 	}
 


### PR DESCRIPTION
## Changes

### 1. Capture Alpaca error in trade_order.notes
When `PlaceOrder` fails in `placeOrder()`, the error message is now persisted in the trade_order's `notes` column before returning the error. Previously, the error message was only propagated through the call stack and ended up in Lambda logs (which get truncated). Now it's queryable directly from the DB:

```sql
SELECT notes FROM trade_order WHERE status = 'ERROR';
```

### 2. Add POST /updateOrders endpoint
Exposes `TradingService.UpdateAllPendingOrders()` as an HTTP endpoint. This lets you reconcile pending trade order fills from Alpaca without triggering a full rebalance cycle. Previously this was only available as a CLI command.

Invoke via Lambda:
```json
{
  "httpMethod": "POST",
  "path": "/updateOrders",
  "pathParameters": {"proxy": "updateOrders"}
}
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new POST API endpoint to trigger updating all pending orders; returns success JSON on completion and requires authentication.

* **Bug Fixes**
  * Improved error handling for order placement: when execution fails, failure details are now appended to the order record to aid troubleshooting and visibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->