### PR TITLE
ci: add Terraform apply to CI pipeline

### DIFF
--- a/.github/actions/has-changes/action.yml
+++ b/.github/actions/has-changes/action.yml
@@ -1,0 +1,26 @@
+name: "Has Changes"
+description: "Check if files have changed compared to master"
+outputs:
+  changed:
+    description: "Whether any of the paths have changed"
+    value: ${{ steps.changed.outputs.changed }}
+runs:
+  using: "composite"
+  steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+
+    - name: Get changed files
+      id: changed
+      shell: bash
+      run: |
+        echo "Comparing against: master"
+        if git diff --name-only origin/master...HEAD | grep -qE '^(${{ inputs.paths }})'; then
+          echo "changed=true" >> $GITHUB_OUTPUT
+        else
+          echo "changed=false" >> $GITHUB_OUTPUT
+        fi
+inputs:
+  paths:
+    description: "Space-separated list of paths to check (use | as OR)"
+    required: true

--- a/.github/workflows/deploy-lambda.yml
+++ b/.github/workflows/deploy-lambda.yml
@@ -17,8 +17,49 @@ env:
   AWS_ACCOUNT_ID: "326651360928"
 
 jobs:
-  deploy:
+  terraform:
     runs-on: ubuntu-latest
+    outputs:
+      changed: steps.changed.outputs.changed
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Check for infrastructure changes
+        id: changed
+        uses: ./.github/actions/has-changes
+        with:
+          paths: terraform/ api/endpoints.yaml
+
+      - name: Configure AWS credentials
+        if: steps.changed.outputs.changed == 'true'
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-region: ${{ env.AWS_REGION }}
+          role-to-assume: arn:aws:iam::${{ env.AWS_ACCOUNT_ID }}:role/factorbacktest-github-deploy
+          role-session-name: factorbacktest-github-deploy
+
+      - name: Set up Terraform
+        if: steps.changed.outputs.changed == 'true'
+        uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_wrapper: false
+
+      - name: Terraform Init
+        if: steps.changed.outputs.changed == 'true'
+        run: terraform -chdir=terraform init
+
+      - name: Terraform Plan
+        if: steps.changed.outputs.changed == 'true'
+        run: terraform -chdir=terraform plan -var="api_gateway_rest_api_id=${{ vars.API_GATEWAY_ID }}"
+
+      - name: Terraform Apply
+        if: steps.changed.outputs.changed == 'true'
+        run: terraform -chdir=terraform apply -auto-approve -var="api_gateway_rest_api_id=${{ vars.API_GATEWAY_ID }}"
+
+  deploy-lambda:
+    runs-on: ubuntu-latest
+    needs: terraform
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Summary
- Adds Terraform apply step to the CI pipeline that runs on merge to master
- Only applies Terraform when `terraform/` or `api/endpoints.yaml` files change
- Lambda deployment continues to run always (after Terraform if applicable)

## Notes
- You need to add `API_GATEWAY_ID` as a repository variable (or secret) in GitHub settings
- Update the IAM role to include API Gateway permissions per the policy you added