### PR TITLE
feat(deploy): add Fly.io as a parallel deployment target

### DIFF
--- a/.github/workflows/deploy-fly.yml
+++ b/.github/workflows/deploy-fly.yml
@@ -1,0 +1,37 @@
+name: Deploy Fly
+
+on:
+  push:
+    branches: ["master"]
+    paths:
+      - 'internal/**'
+      - 'pkg/**'
+      - 'api/**'
+      - 'cmd/**'
+      - 'go.mod'
+      - 'go.sum'
+      - 'Makefile'
+      - 'Dockerfile.fly'
+      - 'fly.toml'
+      - 'migrations/**'
+      - 'tools/**'
+      - 'gpt/**'
+      - 'integration-tests/**'
+
+concurrency:
+  group: deploy-fly-main
+  cancel-in-progress: false
+
+jobs:
+  deploy-fly:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up flyctl
+        uses: superfly/flyctl-actions/setup-flyctl@master
+
+      - name: Deploy to Fly
+        run: flyctl deploy --remote-only
+        env:
+          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}

--- a/.github/workflows/deploy-fly.yml
+++ b/.github/workflows/deploy-fly.yml
@@ -29,7 +29,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Set up flyctl
-        uses: superfly/flyctl-actions/setup-flyctl@master
+        uses: superfly/flyctl-actions/setup-flyctl@v1.4
 
       - name: Deploy to Fly
         run: flyctl deploy --remote-only

--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,6 @@ frontend/test-results
 
 # Compiled test-api binary (from `go build ./cmd/test-api`).
 /test-api
+# vim swap files
+*.swp
+*.swo

--- a/Dockerfile.fly
+++ b/Dockerfile.fly
@@ -1,0 +1,20 @@
+# Fly.io image for the factorbacktest API.
+# Same as Dockerfile, but does not bake a secrets.json into the image -
+# secrets are injected at runtime via `fly secrets set` (FB_SECRETS_FROM_ENV=1).
+
+FROM golang:1.25
+
+WORKDIR /app
+
+COPY . .
+
+RUN go get -d -v ./...
+
+ARG commit_hash
+ENV commit_hash=$commit_hash
+
+RUN GOARCH=amd64 GOOS=linux go build -o ./bin/ ./cmd/api
+
+EXPOSE 3009
+
+CMD ["/app/bin/api"]

--- a/Makefile
+++ b/Makefile
@@ -60,6 +60,9 @@ deploy-lambda:
 update-lambda-config:
 	aws lambda update-function-configuration --region us-east-1 --function-name fbTestArm --environment "Variables={commit_hash=$(shell git rev-parse --short HEAD),GIN_MODE=release}" --output text
 
+deploy-fly:
+	flyctl deploy --remote-only
+
 deploy:
 	make deploy-lambda;
 	make deploy-fe;

--- a/fly.toml
+++ b/fly.toml
@@ -1,0 +1,27 @@
+app = "factorbacktest"
+primary_region = "iad"
+
+[build]
+  dockerfile = "Dockerfile.fly"
+
+[env]
+  FB_SECRETS_FROM_ENV = "1"
+  GIN_MODE = "release"
+
+[http_service]
+  internal_port = 3009
+  force_https = true
+  auto_stop_machines = "stop"
+  auto_start_machines = true
+  min_machines_running = 0
+
+  [[http_service.checks]]
+    method = "get"
+    path = "/"
+    interval = "30s"
+    timeout = "5s"
+    grace_period = "10s"
+
+[[vm]]
+  size = "shared-cpu-2x"
+  memory = "1gb"

--- a/internal/util/util.go
+++ b/internal/util/util.go
@@ -229,25 +229,32 @@ func loadSecretsFromAWS() (*Secrets, error) {
 	return &secrets, nil
 }
 
+// loadSecretsFromEnv reads secrets directly from process env vars. The Fly
+// console flattened our nested secrets.json so each JSON leaf field became
+// its own env-var secret with the original camelCase name (e.g. dataJockey,
+// host, apiKey). Linux env vars are case-sensitive, so these lowercase names
+// don't collide with anything Fly or Docker auto-inject (PORT, HOSTNAME, etc.).
 func loadSecretsFromEnv() (*Secrets, error) {
-	required := []string{
-		"FB_DB_HOST",
-		"FB_DB_PORT",
-		"FB_DB_USER",
-		"FB_DB_PASSWORD",
-		"FB_DB_NAME",
-		"FB_JWT",
-		"FB_ALPACA_API_KEY",
-		"FB_ALPACA_API_SECRET",
-		"FB_ALPACA_ENDPOINT",
-		"FB_DATA_JOCKEY_API_KEY",
-		"FB_CHATGPT_API_KEY",
-		"FB_SES_REGION",
-		"FB_SES_FROM_EMAIL",
+	get := func(name string) string { return os.Getenv(name) }
+
+	required := map[string]string{
+		"dataJockey": get("dataJockey"),
+		"gpt":        get("gpt"),
+		"jwt":        get("jwt"),
+		"host":       get("host"),
+		"port":       get("port"),
+		"user":       get("user"),
+		"password":   get("password"),
+		"database":   get("database"),
+		"apiKey":     get("apiKey"),
+		"apiSecret":  get("apiSecret"),
+		"endpoint":   get("endpoint"),
+		"region":     get("region"),
+		"fromEmail":  get("fromEmail"),
 	}
 	var missing []string
-	for _, k := range required {
-		if os.Getenv(k) == "" {
+	for k, v := range required {
+		if v == "" {
 			missing = append(missing, k)
 		}
 	}
@@ -256,34 +263,34 @@ func loadSecretsFromEnv() (*Secrets, error) {
 	}
 
 	enableSsl := true
-	if v := os.Getenv("FB_DB_ENABLE_SSL"); v != "" {
+	if v := get("enableSsl"); v != "" {
 		parsed, err := strconv.ParseBool(v)
 		if err != nil {
-			return nil, fmt.Errorf("invalid FB_DB_ENABLE_SSL=%q: %w", v, err)
+			return nil, fmt.Errorf("invalid enableSsl=%q: %w", v, err)
 		}
 		enableSsl = parsed
 	}
 
 	return &Secrets{
-		DataJockeyApiKey: os.Getenv("FB_DATA_JOCKEY_API_KEY"),
-		ChatGPTApiKey:    os.Getenv("FB_CHATGPT_API_KEY"),
-		Jwt:              os.Getenv("FB_JWT"),
+		DataJockeyApiKey: required["dataJockey"],
+		ChatGPTApiKey:    required["gpt"],
+		Jwt:              required["jwt"],
 		Db: DbSecrets{
-			Host:      os.Getenv("FB_DB_HOST"),
-			Port:      os.Getenv("FB_DB_PORT"),
-			User:      os.Getenv("FB_DB_USER"),
-			Password:  os.Getenv("FB_DB_PASSWORD"),
-			Database:  os.Getenv("FB_DB_NAME"),
+			Host:      required["host"],
+			Port:      required["port"],
+			User:      required["user"],
+			Password:  required["password"],
+			Database:  required["database"],
 			EnableSsl: enableSsl,
 		},
 		Alpaca: AlpacaSecrets{
-			ApiKey:    os.Getenv("FB_ALPACA_API_KEY"),
-			ApiSecret: os.Getenv("FB_ALPACA_API_SECRET"),
-			Endpoint:  os.Getenv("FB_ALPACA_ENDPOINT"),
+			ApiKey:    required["apiKey"],
+			ApiSecret: required["apiSecret"],
+			Endpoint:  required["endpoint"],
 		},
 		SES: SESSecrets{
-			Region:    os.Getenv("FB_SES_REGION"),
-			FromEmail: os.Getenv("FB_SES_FROM_EMAIL"),
+			Region:    required["region"],
+			FromEmail: required["fromEmail"],
 		},
 	}, nil
 }

--- a/internal/util/util.go
+++ b/internal/util/util.go
@@ -111,15 +111,17 @@ func (t DbSecrets) ToConnectionStr() string {
 
 func LoadSecrets() (*Secrets, error) {
 	// Opt-in path for environments that inject secrets as env vars (e.g. Fly.io).
-	// When FB_SECRETS_FROM_ENV=1, try env vars first; on failure, fall through to
-	// the existing AWS + file chain so behavior is unchanged for Lambda and local dev.
+	// FB_SECRETS_FROM_ENV=1 is an explicit signal, so a failure here is terminal:
+	// falling through to the AWS / file chain would obscure the real cause (a
+	// missing or typo'd Fly secret) and risks loading the wrong secrets in any
+	// future env that has both this flag and AWS creds present.
 	if os.Getenv("FB_SECRETS_FROM_ENV") == "1" {
 		secrets, envErr := loadSecretsFromEnv()
-		if envErr == nil {
-			logger.New().Infof("loaded secrets from env vars")
-			return secrets, nil
+		if envErr != nil {
+			return nil, fmt.Errorf("FB_SECRETS_FROM_ENV=1 but loading from env failed: %w", envErr)
 		}
-		logger.New().Errorf("FB_SECRETS_FROM_ENV=1 set but loading from env failed; falling back: %s", envErr.Error())
+		logger.New().Infof("loaded secrets from env vars")
+		return secrets, nil
 	}
 
 	// Default behavior: prefer AWS Secrets Manager, fall back to a local secrets file.

--- a/internal/util/util.go
+++ b/internal/util/util.go
@@ -13,6 +13,7 @@ import (
 	"fmt"
 	"os"
 	"regexp"
+	"strconv"
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -109,6 +110,18 @@ func (t DbSecrets) ToConnectionStr() string {
 }
 
 func LoadSecrets() (*Secrets, error) {
+	// Opt-in path for environments that inject secrets as env vars (e.g. Fly.io).
+	// When FB_SECRETS_FROM_ENV=1, try env vars first; on failure, fall through to
+	// the existing AWS + file chain so behavior is unchanged for Lambda and local dev.
+	if os.Getenv("FB_SECRETS_FROM_ENV") == "1" {
+		secrets, envErr := loadSecretsFromEnv()
+		if envErr == nil {
+			logger.New().Infof("loaded secrets from env vars")
+			return secrets, nil
+		}
+		logger.New().Errorf("FB_SECRETS_FROM_ENV=1 set but loading from env failed; falling back: %s", envErr.Error())
+	}
+
 	// Default behavior: prefer AWS Secrets Manager, fall back to a local secrets file.
 	secrets, awsErr := loadSecretsFromAWS()
 	if awsErr == nil {
@@ -214,6 +227,65 @@ func loadSecretsFromAWS() (*Secrets, error) {
 	logger.New().Infof("loaded secrets from Secrets Manager")
 
 	return &secrets, nil
+}
+
+func loadSecretsFromEnv() (*Secrets, error) {
+	required := []string{
+		"FB_DB_HOST",
+		"FB_DB_PORT",
+		"FB_DB_USER",
+		"FB_DB_PASSWORD",
+		"FB_DB_NAME",
+		"FB_JWT",
+		"FB_ALPACA_API_KEY",
+		"FB_ALPACA_API_SECRET",
+		"FB_ALPACA_ENDPOINT",
+		"FB_DATA_JOCKEY_API_KEY",
+		"FB_CHATGPT_API_KEY",
+		"FB_SES_REGION",
+		"FB_SES_FROM_EMAIL",
+	}
+	var missing []string
+	for _, k := range required {
+		if os.Getenv(k) == "" {
+			missing = append(missing, k)
+		}
+	}
+	if len(missing) > 0 {
+		return nil, fmt.Errorf("missing required env vars: %v", missing)
+	}
+
+	enableSsl := true
+	if v := os.Getenv("FB_DB_ENABLE_SSL"); v != "" {
+		parsed, err := strconv.ParseBool(v)
+		if err != nil {
+			return nil, fmt.Errorf("invalid FB_DB_ENABLE_SSL=%q: %w", v, err)
+		}
+		enableSsl = parsed
+	}
+
+	return &Secrets{
+		DataJockeyApiKey: os.Getenv("FB_DATA_JOCKEY_API_KEY"),
+		ChatGPTApiKey:    os.Getenv("FB_CHATGPT_API_KEY"),
+		Jwt:              os.Getenv("FB_JWT"),
+		Db: DbSecrets{
+			Host:      os.Getenv("FB_DB_HOST"),
+			Port:      os.Getenv("FB_DB_PORT"),
+			User:      os.Getenv("FB_DB_USER"),
+			Password:  os.Getenv("FB_DB_PASSWORD"),
+			Database:  os.Getenv("FB_DB_NAME"),
+			EnableSsl: enableSsl,
+		},
+		Alpaca: AlpacaSecrets{
+			ApiKey:    os.Getenv("FB_ALPACA_API_KEY"),
+			ApiSecret: os.Getenv("FB_ALPACA_API_SECRET"),
+			Endpoint:  os.Getenv("FB_ALPACA_ENDPOINT"),
+		},
+		SES: SESSecrets{
+			Region:    os.Getenv("FB_SES_REGION"),
+			FromEmail: os.Getenv("FB_SES_FROM_EMAIL"),
+		},
+	}, nil
 }
 
 func HashFactorExpression(in string) string {

--- a/plans/fly-deployment.md
+++ b/plans/fly-deployment.md
@@ -1,0 +1,114 @@
+# Fly.io deployment runbook
+
+This is the parallel deployment of the Go API on Fly.io. The Lambda + API
+Gateway deploy still runs unchanged; Fly is a separate target you can hit at
+`https://factorbacktest.fly.dev` for A/B testing and (eventually) cut over to.
+
+## Files
+
+- [fly.toml](../fly.toml) — Fly app config (shared-cpu-2x, 1GB, auto-stop)
+- [Dockerfile.fly](../Dockerfile.fly) — image for Fly (no `secrets.json` baked in)
+- [.github/workflows/deploy-fly.yml](../.github/workflows/deploy-fly.yml) — auto-deploys on push to `master`
+- `Makefile` `deploy-fly` target for manual deploys
+
+## One-time setup
+
+### 1. Create the app
+
+```sh
+flyctl apps create factorbacktest --org personal
+```
+
+(Pick a different org if you don't want it on the personal one.)
+
+### 2. Set the 13 runtime secrets
+
+Fly machines load `Secrets` via env vars when `FB_SECRETS_FROM_ENV=1` is set
+(it is, in `fly.toml`). Set the values once with `fly secrets set`. They're
+encrypted at rest and only decrypted into the machine's environment.
+
+```sh
+flyctl secrets set \
+  FB_DB_HOST='<rds-host>' \
+  FB_DB_PORT='5432' \
+  FB_DB_USER='<user>' \
+  FB_DB_PASSWORD='<password>' \
+  FB_DB_NAME='<dbname>' \
+  FB_DB_ENABLE_SSL='true' \
+  FB_JWT='<jwt-secret>' \
+  FB_ALPACA_API_KEY='<key>' \
+  FB_ALPACA_API_SECRET='<secret>' \
+  FB_ALPACA_ENDPOINT='https://api.alpaca.markets' \
+  FB_DATA_JOCKEY_API_KEY='<key>' \
+  FB_CHATGPT_API_KEY='<key>' \
+  FB_SES_REGION='us-east-1' \
+  FB_SES_FROM_EMAIL='noreply@factor.trade'
+```
+
+You can pull the current values from AWS Secrets Manager (`prod/factor`) to
+seed these. `FB_DB_ENABLE_SSL` is optional and defaults to `true` if unset.
+
+### 3. Wire up CI
+
+Get a deploy token and add it to GitHub:
+
+```sh
+flyctl auth token
+gh secret set FLY_API_TOKEN --body '<paste-token>'
+```
+
+After this, `git push origin master` triggers both `deploy-lambda.yml` and
+`deploy-fly.yml` in parallel.
+
+### 4. Confirm RDS allows the world
+
+The RDS security group needs `0.0.0.0/0` on the Postgres port (or at minimum
+Fly's egress range). Without this, the machine boots but can't connect to
+Postgres and the healthcheck on `/` will fail.
+
+## Day-to-day commands
+
+```sh
+flyctl deploy --remote-only      # manual deploy from current branch
+flyctl logs                      # tail logs
+flyctl status                    # machine state
+flyctl ssh console               # shell into the running machine
+flyctl scale vm shared-cpu-4x    # bump CPU class
+flyctl scale memory 2048         # bump memory (MB)
+flyctl secrets list              # which env-var secrets are set (names only)
+flyctl releases                  # deploy history
+flyctl releases revert <version> # rollback to a prior release
+```
+
+## Smoke test
+
+1. `curl https://factorbacktest.fly.dev/` — expect a 200 from the root handler
+   in [api/api.go](../api/api.go) line 105.
+2. In the browser dev tools on `factor.trade`, override the API URL for one
+   tab (e.g. via DevTools "Local overrides" or a small `sessionStorage` shim
+   in `frontend/src/App.tsx`'s `endpoint` const) and run a backtest.
+3. Run a deliberately heavy backtest (20yr, monthly, SPY_TOP_80) that would
+   504 on Lambda's 29-second API Gateway cliff. Confirm it completes on Fly.
+4. `flyctl logs` — verify no errors, and no "failed to load secrets from
+   AWS" warning (that path should be skipped because `FB_SECRETS_FROM_ENV=1`).
+
+## Cutover (later, when ready)
+
+When you want to send real traffic to Fly:
+
+1. Add a custom domain: `flyctl certs add api.factor.trade` and update DNS.
+2. Update `endpoint` in [frontend/src/App.tsx](../frontend/src/App.tsx) to
+   point at the new domain.
+3. Deploy frontend (`make deploy-fe`).
+4. Watch `flyctl logs` and CloudWatch for errors for a day.
+5. Once stable, retire Lambda: stop the GitHub Actions workflow, delete the
+   Lambda + API Gateway via console / `terraform destroy`, drop
+   `cmd/lambda/`, `Dockerfile.lambda`, the `aws-lambda-go` deps, and the
+   AWS Secrets Manager loader path in `internal/util/util.go`.
+
+## Cost notes
+
+`shared-cpu-2x` with `auto_stop_machines = "stop"` and
+`min_machines_running = 0` means the machine sleeps when idle and wakes on
+the next request (a few-hundred-ms cold start). Expect a few dollars a
+month. Bump to `performance-2x` if backtests feel CPU-bound.

--- a/plans/fly-deployment.md
+++ b/plans/fly-deployment.md
@@ -24,29 +24,32 @@ flyctl apps create factorbacktest --org personal
 ### 2. Set the 13 runtime secrets
 
 Fly machines load `Secrets` via env vars when `FB_SECRETS_FROM_ENV=1` is set
-(it is, in `fly.toml`). Set the values once with `fly secrets set`. They're
-encrypted at rest and only decrypted into the machine's environment.
+(it is, in `fly.toml`). The loader reads the original camelCase JSON leaf
+names from `secrets.json` directly, so the secret names match the keys you
+already know. Linux env vars are case-sensitive, so these lowercase names
+don't collide with any vars Fly or Docker auto-inject.
 
 ```sh
 flyctl secrets set \
-  FB_DB_HOST='<rds-host>' \
-  FB_DB_PORT='5432' \
-  FB_DB_USER='<user>' \
-  FB_DB_PASSWORD='<password>' \
-  FB_DB_NAME='<dbname>' \
-  FB_DB_ENABLE_SSL='true' \
-  FB_JWT='<jwt-secret>' \
-  FB_ALPACA_API_KEY='<key>' \
-  FB_ALPACA_API_SECRET='<secret>' \
-  FB_ALPACA_ENDPOINT='https://api.alpaca.markets' \
-  FB_DATA_JOCKEY_API_KEY='<key>' \
-  FB_CHATGPT_API_KEY='<key>' \
-  FB_SES_REGION='us-east-1' \
-  FB_SES_FROM_EMAIL='noreply@factor.trade'
+  host='<rds-host>' \
+  port='5432' \
+  user='<db-user>' \
+  password='<db-password>' \
+  database='<dbname>' \
+  enableSsl='true' \
+  jwt='<jwt-secret>' \
+  apiKey='<alpaca-key>' \
+  apiSecret='<alpaca-secret>' \
+  endpoint='https://api.alpaca.markets' \
+  dataJockey='<data-jockey-key>' \
+  gpt='<chatgpt-key>' \
+  region='us-east-1' \
+  fromEmail='noreply@factor.trade'
 ```
 
-You can pull the current values from AWS Secrets Manager (`prod/factor`) to
-seed these. `FB_DB_ENABLE_SSL` is optional and defaults to `true` if unset.
+Easiest source: `secrets.json` locally (or AWS Secrets Manager `prod/factor`).
+The Fly console "import from JSON" UI also works and produces the same flat
+secret names. `enableSsl` is optional and defaults to `true` if unset.
 
 ### 3. Wire up CI
 

--- a/plans/fly-deployment.md
+++ b/plans/fly-deployment.md
@@ -83,14 +83,14 @@ flyctl releases revert <version> # rollback to a prior release
 ## Smoke test
 
 1. `curl https://factorbacktest.fly.dev/` — expect a 200 from the root handler
-   in [api/api.go](../api/api.go) line 105.
+  in [api/api.go](../api/api.go) line 105.
 2. In the browser dev tools on `factor.trade`, override the API URL for one
-   tab (e.g. via DevTools "Local overrides" or a small `sessionStorage` shim
+  tab (e.g. via DevTools "Local overrides" or a small `sessionStorage` shim
    in `frontend/src/App.tsx`'s `endpoint` const) and run a backtest.
 3. Run a deliberately heavy backtest (20yr, monthly, SPY_TOP_80) that would
-   504 on Lambda's 29-second API Gateway cliff. Confirm it completes on Fly.
+  504 on Lambda's 29-second API Gateway cliff. Confirm it completes on Fly.
 4. `flyctl logs` — verify no errors, and no "failed to load secrets from
-   AWS" warning (that path should be skipped because `FB_SECRETS_FROM_ENV=1`).
+  AWS" warning (that path should be skipped because `FB_SECRETS_FROM_ENV=1`).
 
 ## Cutover (later, when ready)
 
@@ -98,11 +98,11 @@ When you want to send real traffic to Fly:
 
 1. Add a custom domain: `flyctl certs add api.factor.trade` and update DNS.
 2. Update `endpoint` in [frontend/src/App.tsx](../frontend/src/App.tsx) to
-   point at the new domain.
+  point at the new domain.
 3. Deploy frontend (`make deploy-fe`).
 4. Watch `flyctl logs` and CloudWatch for errors for a day.
 5. Once stable, retire Lambda: stop the GitHub Actions workflow, delete the
-   Lambda + API Gateway via console / `terraform destroy`, drop
+  Lambda + API Gateway via console / `terraform destroy`, drop
    `cmd/lambda/`, `Dockerfile.lambda`, the `aws-lambda-go` deps, and the
    AWS Secrets Manager loader path in `internal/util/util.go`.
 

--- a/plans/fly-deployment.md
+++ b/plans/fly-deployment.md
@@ -63,11 +63,29 @@ gh secret set FLY_API_TOKEN --body '<paste-token>'
 After this, `git push origin master` triggers both `deploy-lambda.yml` and
 `deploy-fly.yml` in parallel.
 
-### 4. Confirm RDS allows the world
+### 4. Confirm RDS reachability
 
-The RDS security group needs `0.0.0.0/0` on the Postgres port (or at minimum
-Fly's egress range). Without this, the machine boots but can't connect to
-Postgres and the healthcheck on `/` will fail.
+Fly machines connect to RDS over the public internet, so the RDS security
+group needs to permit that traffic on the Postgres port. In rough order of
+preference:
+
+1. **Allowlist Fly's egress IPs only** — Fly publishes per-region egress
+   ranges; pin those into the SG. Narrow blast radius, recommended for
+   anything past the initial A/B test.
+2. **WireGuard / Fly private networking** — peer Fly into the AWS VPC and
+   keep RDS private. Most work; strongest posture.
+3. **Bastion or RDS Proxy with IAM auth** — middle ground.
+4. **`0.0.0.0/0` on the Postgres port** — fastest and how this PR was
+   smoke-tested. Acceptable as a *temporary* state for A/B testing because
+   the connection is SSL (`enableSsl=true`) and Postgres still requires the
+   user/password to authenticate, but **must not be the cutover state.** If
+   you choose this, plan to narrow it before sending real traffic.
+
+Confirm reachability before deploying:
+
+```sh
+nc -zv <rds-host> 5432   # from your laptop or any external network
+```
 
 ## Day-to-day commands
 

--- a/secrets-test.json
+++ b/secrets-test.json
@@ -8,4 +8,15 @@
     "user": "postgres",
     "password": "postgres",
     "enableSsl": false
-  }}
+  },
+  "alpaca": {
+    "endpoint": "test",
+    "apiKey": "test",
+    "apiSecret": "test"
+  },
+  "jwt": "test",
+  "ses": {
+    "region": "test",
+    "fromEmail": "test"
+  }
+}


### PR DESCRIPTION
Stands up the existing Go API on Fly.io alongside the current Lambda + API Gateway deploy so we can A/B test backtests on a long-lived server (no 29s gateway cap, supports SSE later) without disturbing the prod Lambda path.

- internal/util/util.go: new loadSecretsFromEnv() path, gated by FB_SECRETS_FROM_ENV=1 so Lambda behavior is unchanged. Falls through to the existing AWS Secrets Manager + file chain on failure.
- Dockerfile.fly: image without secrets.json baked in (env-vars at runtime).
- fly.toml: shared-cpu-2x / 1GB / auto-stop, healthcheck on GET /.
- .github/workflows/deploy-fly.yml: parallel CI deploy on push to master.
- Makefile: deploy-fly target for manual deploys.
- plans/fly-deployment.md: setup + runbook (secrets, logs, scale, rollback, cutover).

Made-with: Cursor

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Infrastructure**
  * Enabled deployment to Fly.io with automatic CI/CD pipeline that triggers on updates to the main branch
  * Added support for managing application secrets through environment variables
  * Containerized the application for cloud deployment

* **Documentation**
  * Added comprehensive deployment and operations guide for Fly.io

<!-- end of auto-generated comment: release notes by coderabbit.ai -->