### PR TITLE
feat(auth): replace Supabase with embedded Better Auth service

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -3,3 +3,7 @@ frontend
 .github
 postgres-data
 secrets-dev.json
+auth-service/node_modules
+auth-service/dist
+auth-service/.env
+auth-service/.env.local

--- a/.github/workflows/deploy-fly.yml
+++ b/.github/workflows/deploy-fly.yml
@@ -17,6 +17,8 @@ on:
       - 'tools/**'
       - 'gpt/**'
       - 'integration-tests/**'
+      - 'auth-service/**'
+      - 'scripts/**'
 
 concurrency:
   group: deploy-fly-main

--- a/Dockerfile.fly
+++ b/Dockerfile.fly
@@ -1,20 +1,65 @@
-# Fly.io image for the factorbacktest API.
-# Same as Dockerfile, but does not bake a secrets.json into the image -
-# secrets are injected at runtime via `fly secrets set` (FB_SECRETS_FROM_ENV=1).
+# Multi-stage Fly.io image: Go API + Node Better Auth sidecar in one container.
+# Both processes run in the same Fly machine. Go binds the public port (3009)
+# and reverse-proxies /api/auth/* to the local Node service on 127.0.0.1:3001.
 
-FROM golang:1.25
+# -----------------------------------------------------------------------------
+# Stage 1: build the Go API binary
+# -----------------------------------------------------------------------------
+FROM golang:1.25 AS go-build
 
-WORKDIR /app
+WORKDIR /src
+
+COPY go.mod go.sum ./
+RUN go mod download
 
 COPY . .
-
-RUN go get -d -v ./...
 
 ARG commit_hash
 ENV commit_hash=$commit_hash
 
-RUN GOARCH=amd64 GOOS=linux go build -o ./bin/ ./cmd/api
+RUN GOARCH=amd64 GOOS=linux CGO_ENABLED=0 go build -o /out/api ./cmd/api
+
+# -----------------------------------------------------------------------------
+# Stage 2: install + build the Node auth-service
+# -----------------------------------------------------------------------------
+FROM node:20-bookworm-slim AS node-build
+
+WORKDIR /src/auth-service
+
+COPY auth-service/package.json auth-service/package-lock.json* ./
+RUN npm ci --no-audit --no-fund
+
+COPY auth-service/ ./
+RUN npm run build
+
+# Drop devDependencies for the runtime image. We keep node_modules around so
+# `node dist/...` works without re-installing at container start.
+RUN npm prune --omit=dev
+
+# -----------------------------------------------------------------------------
+# Stage 3: runtime image with both binaries + Node + a tiny supervisor
+# -----------------------------------------------------------------------------
+FROM node:20-bookworm-slim AS runtime
+
+WORKDIR /app
+
+# `tini` reaps zombies and forwards signals so SIGTERM from Fly cleanly stops
+# both the Go and Node processes.
+RUN apt-get update && apt-get install -y --no-install-recommends tini ca-certificates curl && rm -rf /var/lib/apt/lists/*
+
+COPY --from=go-build  /out/api                    /app/api
+COPY --from=node-build /src/auth-service/dist     /app/auth-service/dist
+COPY --from=node-build /src/auth-service/node_modules /app/auth-service/node_modules
+COPY --from=node-build /src/auth-service/package.json /app/auth-service/package.json
+
+COPY scripts/start.sh /app/start.sh
+RUN chmod +x /app/start.sh
+
+ARG commit_hash
+ENV commit_hash=$commit_hash
+ENV NODE_ENV=production
 
 EXPOSE 3009
 
-CMD ["/app/bin/api"]
+ENTRYPOINT ["/usr/bin/tini", "--"]
+CMD ["/app/start.sh"]

--- a/api/api.go
+++ b/api/api.go
@@ -48,6 +48,10 @@ type ApiHandler struct {
 	StrategyService              service.StrategyService
 	StrategySummaryApp           app.StrategySummaryApp
 	JwtDecodeToken               string
+	// BetterAuthJwksURL is the URL the Go API hits to fetch the JWKS used to
+	// verify Better Auth-issued JWTs. In production it points at the local
+	// auth-service sidecar (default `http://127.0.0.1:3001/api/auth/jwks`).
+	BetterAuthJwksURL string
 
 	AlpacaRepository repository.AlpacaRepository
 }
@@ -94,8 +98,25 @@ func (m ApiHandler) InitializeRouterEngine(ctx context.Context) *gin.Engine {
 	}
 	engine.Use(cors.New(cors.Config{
 		AllowOrigins: allowedOrigins,
-		AllowHeaders: []string{"Authorization", "Content-Type"},
+		AllowMethods: []string{"GET", "POST", "PUT", "DELETE", "OPTIONS", "PATCH"},
+		AllowHeaders: []string{"Authorization", "Content-Type", "Cookie"},
+		// Better Auth issues HttpOnly session cookies. The browser will only
+		// attach them on cross-origin requests when AllowCredentials is true
+		// AND the origin is not a wildcard (which we already enforce).
+		AllowCredentials: true,
+		ExposeHeaders:    []string{"Set-Cookie"},
 	}))
+	// Reverse-proxy /api/auth/* to the local Better Auth sidecar BEFORE the
+	// JWT middleware. The auth-service handles its own request validation
+	// (CSRF, OTPs, OAuth callbacks) and we don't want our JWT middleware
+	// rejecting unauthenticated calls like sign-in or token refresh.
+	authProxy, err := newBetterAuthProxy()
+	if err != nil {
+		lg.Errorf("failed to build better-auth proxy: %v", err)
+	} else {
+		engine.Any("/api/auth/*proxyPath", authProxy)
+	}
+
 	engine.Use(m.getGoogleAuthMiddleware)
 	engine.Use(m.logRequestMiddlware)
 	engine.Use(func(ctx *gin.Context) {
@@ -275,34 +296,75 @@ func (m ApiHandler) getGoogleAuthMiddleware(c *gin.Context) {
 
 	var userInput *model.UserAccount
 
-	parsedJwt, supabaseErr := parseSupabaseJWT(jwtStr, m.JwtDecodeToken)
-	userDetails, googleAuthErr := googleauth.GetUserDetails(jwtStr)
-
-	if supabaseErr == nil {
-		userInput = &model.UserAccount{
-			PhoneNumber: parsedJwt.PhoneNumber,
-			Provider:    model.UserAccountProviderType_Supabase,
-			ProviderID:  &parsedJwt.Subject,
-		}
-		if parsedJwt.Email != nil && *parsedJwt.Email != "" {
-			userInput.Email = parsedJwt.Email
-		}
-		if parsedJwt.Name != "" {
-			splits := strings.Split(parsedJwt.Name, " ")
-			userInput.FirstName = &splits[0]
-			if len(splits) > 1 {
-				userInput.LastName = util.StringPointer(strings.Join(splits[1:], " "))
+	// Resolution order during the Supabase -> Better Auth cutover:
+	//   1. Better Auth JWT (EdDSA via JWKS) - the new default
+	//   2. Supabase JWT (HS256 / ES256 via JWKS) - kept until existing sessions expire
+	//   3. Google ID token - used by older direct integrations
+	// Once Supabase is fully decommissioned, branches 2 and the related
+	// SupabaseJWT code in api/auth.go can be removed.
+	var betterAuthErr error
+	if m.BetterAuthJwksURL != "" {
+		var baJwt *BetterAuthJWT
+		baJwt, betterAuthErr = parseBetterAuthJWT(jwtStr, m.BetterAuthJwksURL)
+		if betterAuthErr == nil {
+			userInput = &model.UserAccount{
+				Provider:    model.UserAccountProviderType_BetterAuth,
+				ProviderID:  &baJwt.Subject,
+				PhoneNumber: baJwt.PhoneNumber,
+			}
+			if baJwt.Email != nil && *baJwt.Email != "" {
+				userInput.Email = baJwt.Email
+			}
+			if baJwt.Name != "" {
+				splits := strings.Split(baJwt.Name, " ")
+				userInput.FirstName = &splits[0]
+				if len(splits) > 1 {
+					userInput.LastName = util.StringPointer(strings.Join(splits[1:], " "))
+				}
 			}
 		}
-	} else if googleAuthErr == nil {
-		userInput = &model.UserAccount{
-			Email:     &userDetails.Email,
-			FirstName: &userDetails.FirstName,
-			LastName:  &userDetails.LastName,
-			Provider:  model.UserAccountProviderType_Google,
+	}
+
+	var supabaseErr error
+	var googleAuthErr error
+	if userInput == nil {
+		var parsedJwt *SupabaseJWT
+		parsedJwt, supabaseErr = parseSupabaseJWT(jwtStr, m.JwtDecodeToken)
+		userDetails, gErr := googleauth.GetUserDetails(jwtStr)
+		googleAuthErr = gErr
+
+		if supabaseErr == nil {
+			userInput = &model.UserAccount{
+				PhoneNumber: parsedJwt.PhoneNumber,
+				Provider:    model.UserAccountProviderType_Supabase,
+				ProviderID:  &parsedJwt.Subject,
+			}
+			if parsedJwt.Email != nil && *parsedJwt.Email != "" {
+				userInput.Email = parsedJwt.Email
+			}
+			if parsedJwt.Name != "" {
+				splits := strings.Split(parsedJwt.Name, " ")
+				userInput.FirstName = &splits[0]
+				if len(splits) > 1 {
+					userInput.LastName = util.StringPointer(strings.Join(splits[1:], " "))
+				}
+			}
+		} else if googleAuthErr == nil {
+			userInput = &model.UserAccount{
+				Email:     &userDetails.Email,
+				FirstName: &userDetails.FirstName,
+				LastName:  &userDetails.LastName,
+				Provider:  model.UserAccountProviderType_Google,
+			}
 		}
-	} else {
-		returnErrorJsonCode(fmt.Errorf("both authentication methods failed: %w | :%w", supabaseErr, googleAuthErr), c, 403)
+	}
+
+	if userInput == nil {
+		returnErrorJsonCode(
+			fmt.Errorf("all authentication methods failed: better_auth=%v supabase=%v google=%v",
+				betterAuthErr, supabaseErr, googleAuthErr),
+			c, 403,
+		)
 		return
 	}
 

--- a/api/api.go
+++ b/api/api.go
@@ -52,6 +52,10 @@ type ApiHandler struct {
 	// verify Better Auth-issued JWTs. In production it points at the local
 	// auth-service sidecar (default `http://127.0.0.1:3001/api/auth/jwks`).
 	BetterAuthJwksURL string
+	// BetterAuthExpectedIssuer is the value the auth-service stamps as `iss`
+	// on every JWT (its `baseURL`). When set, JWTs whose `iss` doesn't match
+	// are rejected. Defense in depth in case the JWKS URL is misconfigured.
+	BetterAuthExpectedIssuer string
 
 	AlpacaRepository repository.AlpacaRepository
 }
@@ -305,7 +309,7 @@ func (m ApiHandler) getGoogleAuthMiddleware(c *gin.Context) {
 	var betterAuthErr error
 	if m.BetterAuthJwksURL != "" {
 		var baJwt *BetterAuthJWT
-		baJwt, betterAuthErr = parseBetterAuthJWT(jwtStr, m.BetterAuthJwksURL)
+		baJwt, betterAuthErr = parseBetterAuthJWT(jwtStr, m.BetterAuthJwksURL, m.BetterAuthExpectedIssuer)
 		if betterAuthErr == nil {
 			userInput = &model.UserAccount{
 				Provider:    model.UserAccountProviderType_BetterAuth,
@@ -360,11 +364,15 @@ func (m ApiHandler) getGoogleAuthMiddleware(c *gin.Context) {
 	}
 
 	if userInput == nil {
-		returnErrorJsonCode(
-			fmt.Errorf("all authentication methods failed: better_auth=%v supabase=%v google=%v",
-				betterAuthErr, supabaseErr, googleAuthErr),
-			c, 403,
-		)
+		// Log per-validator errors server-side for ops debugging; return a
+		// generic 403 to the client so we don't expose token-validation
+		// internals to attackers tuning forged tokens.
+		logger.FromContext(c).With(
+			"better_auth_err", fmt.Sprintf("%v", betterAuthErr),
+			"supabase_err", fmt.Sprintf("%v", supabaseErr),
+			"google_err", fmt.Sprintf("%v", googleAuthErr),
+		).Warn("all auth methods failed")
+		returnErrorJsonCode(fmt.Errorf("invalid or expired credentials"), c, 403)
 		return
 	}
 

--- a/api/auth_proxy.go
+++ b/api/auth_proxy.go
@@ -1,0 +1,54 @@
+package api
+
+import (
+	"net/http"
+	"net/http/httputil"
+	"net/url"
+	"os"
+	"time"
+
+	"github.com/gin-gonic/gin"
+)
+
+// betterAuthInternalURL is the address of the local Better Auth (Node) sidecar.
+// In production it runs in the same Fly machine as the Go API and binds to
+// localhost only, so we don't need any TLS or auth on this hop.
+func betterAuthInternalURL() string {
+	if v := os.Getenv("BETTER_AUTH_INTERNAL_URL"); v != "" {
+		return v
+	}
+	return "http://127.0.0.1:3001"
+}
+
+// newBetterAuthProxy constructs a single-host reverse proxy that forwards
+// /api/auth/* to the local Node Better Auth service. We deliberately do NOT
+// inject any auth headers, do not read the JWT, and do not modify the
+// response body. Cookies and Set-Cookie headers pass through untouched so
+// session cookies work on the same domain.
+func newBetterAuthProxy() (gin.HandlerFunc, error) {
+	target, err := url.Parse(betterAuthInternalURL())
+	if err != nil {
+		return nil, err
+	}
+	proxy := httputil.NewSingleHostReverseProxy(target)
+
+	// Tighter transport timeouts so a hung sidecar doesn't tie up Go workers.
+	proxy.Transport = &http.Transport{
+		ResponseHeaderTimeout: 30 * time.Second,
+		IdleConnTimeout:       90 * time.Second,
+	}
+
+	originalDirector := proxy.Director
+	proxy.Director = func(req *http.Request) {
+		originalDirector(req)
+		req.Host = target.Host
+	}
+
+	proxy.ErrorHandler = func(w http.ResponseWriter, r *http.Request, err error) {
+		http.Error(w, "auth service unavailable: "+err.Error(), http.StatusBadGateway)
+	}
+
+	return func(c *gin.Context) {
+		proxy.ServeHTTP(c.Writer, c.Request)
+	}, nil
+}

--- a/api/auth_proxy.go
+++ b/api/auth_proxy.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"log"
 	"net/http"
 	"net/http/httputil"
 	"net/url"
@@ -45,7 +46,10 @@ func newBetterAuthProxy() (gin.HandlerFunc, error) {
 	}
 
 	proxy.ErrorHandler = func(w http.ResponseWriter, r *http.Request, err error) {
-		http.Error(w, "auth service unavailable: "+err.Error(), http.StatusBadGateway)
+		// Log internals server-side; return a generic message so we don't
+		// leak transport-level details (TCP errors, TLS state, etc.).
+		log.Printf("auth proxy upstream error: %v", err)
+		http.Error(w, "auth service unavailable", http.StatusBadGateway)
 	}
 
 	return func(c *gin.Context) {

--- a/api/better_auth.go
+++ b/api/better_auth.go
@@ -5,6 +5,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"strings"
 	"sync"
@@ -12,6 +13,14 @@ import (
 
 	jwtv5 "github.com/golang-jwt/jwt/v5"
 )
+
+// jwksHTTPClient bounds JWKS fetch latency so a slow/hung sidecar can't
+// pin Go request goroutines on cache miss.
+var jwksHTTPClient = &http.Client{Timeout: 10 * time.Second}
+
+// maxJWKSBodyBytes caps the JWKS response we'll read into memory. JWKS
+// payloads are well under 10 KiB in practice; anything larger is suspicious.
+const maxJWKSBodyBytes = 256 * 1024
 
 // BetterAuthJWT mirrors the claims emitted by Better Auth's JWT plugin.
 // The plugin signs with EdDSA / Ed25519 by default, and exposes the public
@@ -62,7 +71,7 @@ func fetchBetterAuthEdDSAKey(jwksURL string, kid string) (ed25519.PublicKey, err
 	}
 	betterAuthJwksMu.RUnlock()
 
-	resp, err := http.Get(jwksURL) // #nosec G107 - JWKS URL is configured by the operator, not an arbitrary token claim.
+	resp, err := jwksHTTPClient.Get(jwksURL) // #nosec G107 - JWKS URL is configured by the operator, not an arbitrary token claim.
 	if err != nil {
 		return nil, fmt.Errorf("fetch JWKS: %w", err)
 	}
@@ -71,8 +80,16 @@ func fetchBetterAuthEdDSAKey(jwksURL string, kid string) (ed25519.PublicKey, err
 		return nil, fmt.Errorf("fetch JWKS: http %d", resp.StatusCode)
 	}
 
+	body, err := io.ReadAll(io.LimitReader(resp.Body, maxJWKSBodyBytes+1))
+	if err != nil {
+		return nil, fmt.Errorf("read JWKS: %w", err)
+	}
+	if len(body) > maxJWKSBodyBytes {
+		return nil, fmt.Errorf("JWKS response too large (>%d bytes)", maxJWKSBodyBytes)
+	}
+
 	var jwks jwkOKPSet
-	if err := json.NewDecoder(resp.Body).Decode(&jwks); err != nil {
+	if err := json.Unmarshal(body, &jwks); err != nil {
 		return nil, fmt.Errorf("decode JWKS: %w", err)
 	}
 
@@ -82,6 +99,14 @@ func fetchBetterAuthEdDSAKey(jwksURL string, kid string) (ed25519.PublicKey, err
 		}
 		if k.Kty != "OKP" || k.Crv != "Ed25519" {
 			return nil, fmt.Errorf("unsupported JWK key type/curve: kty=%s crv=%s (only OKP/Ed25519 supported)", k.Kty, k.Crv)
+		}
+		// If the issuer publishes `use` or `alg`, demand they match. (Both are
+		// optional per RFC 7517, so empty values are allowed for backward compat.)
+		if k.Use != "" && k.Use != "sig" {
+			return nil, fmt.Errorf("JWK use=%q is not 'sig'", k.Use)
+		}
+		if k.Alg != "" && k.Alg != "EdDSA" {
+			return nil, fmt.Errorf("JWK alg=%q is not 'EdDSA'", k.Alg)
 		}
 		raw, err := base64.RawURLEncoding.DecodeString(k.X)
 		if err != nil {
@@ -102,7 +127,12 @@ func fetchBetterAuthEdDSAKey(jwksURL string, kid string) (ed25519.PublicKey, err
 
 // parseBetterAuthJWT validates `jwtStr` against the JWKS at `jwksURL` and
 // returns the parsed claims. Only EdDSA / Ed25519 is accepted.
-func parseBetterAuthJWT(jwtStr string, jwksURL string) (*BetterAuthJWT, error) {
+//
+// `expectedIssuer`, when non-empty, is compared against the token's `iss`
+// claim. Better Auth signs `iss` with the configured `baseURL`, so this
+// pins tokens to one specific auth instance and protects against token
+// reuse if the JWKS URL is ever misconfigured.
+func parseBetterAuthJWT(jwtStr string, jwksURL string, expectedIssuer string) (*BetterAuthJWT, error) {
 	parser := jwtv5.NewParser(jwtv5.WithValidMethods([]string{jwtv5.SigningMethodEdDSA.Alg()}))
 	token, err := parser.Parse(jwtStr, func(t *jwtv5.Token) (interface{}, error) {
 		kidVal, ok := t.Header["kid"]
@@ -137,6 +167,9 @@ func parseBetterAuthJWT(jwtStr string, jwksURL string) (*BetterAuthJWT, error) {
 	}
 	if strings.TrimSpace(parsed.Subject) == "" {
 		return nil, fmt.Errorf("better-auth jwt missing sub")
+	}
+	if expectedIssuer != "" && parsed.Issuer != expectedIssuer {
+		return nil, fmt.Errorf("better-auth jwt issuer mismatch: got %q, want %q", parsed.Issuer, expectedIssuer)
 	}
 	return &parsed, nil
 }

--- a/api/better_auth.go
+++ b/api/better_auth.go
@@ -1,0 +1,142 @@
+package api
+
+import (
+	"crypto/ed25519"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+	"sync"
+	"time"
+
+	jwtv5 "github.com/golang-jwt/jwt/v5"
+)
+
+// BetterAuthJWT mirrors the claims emitted by Better Auth's JWT plugin.
+// The plugin signs with EdDSA / Ed25519 by default, and exposes the public
+// keys via a JWKS endpoint (default path `${baseURL}${basePath}/jwks`).
+type BetterAuthJWT struct {
+	Subject              string  `json:"sub"`
+	UserID               string  `json:"id"`
+	Email                *string `json:"email,omitempty"`
+	EmailVerified        bool    `json:"emailVerified,omitempty"`
+	Name                 string  `json:"name,omitempty"`
+	Image                *string `json:"image,omitempty"`
+	PhoneNumber          *string `json:"phoneNumber,omitempty"`
+	PhoneNumberVerified  bool    `json:"phoneNumberVerified,omitempty"`
+	Issuer               string  `json:"iss,omitempty"`
+	Audience             string  `json:"aud,omitempty"`
+	IssuedAt             int64   `json:"iat,omitempty"`
+	ExpiresAt            int64   `json:"exp,omitempty"`
+}
+
+// jwkOKPKey is the subset of a JWKS entry needed to reconstruct an Ed25519
+// public key. Better Auth emits `{kty:"OKP", crv:"Ed25519", x:"...", kid:"..."}`.
+type jwkOKPKey struct {
+	Kty string `json:"kty"`
+	Crv string `json:"crv"`
+	Use string `json:"use"`
+	Kid string `json:"kid"`
+	Alg string `json:"alg"`
+	X   string `json:"x"`
+}
+
+type jwkOKPSet struct {
+	Keys []jwkOKPKey `json:"keys"`
+}
+
+var (
+	betterAuthJwksMu    sync.RWMutex
+	betterAuthJwksCache = map[string]ed25519.PublicKey{} // key = jwksURL + "|" + kid
+)
+
+// fetchBetterAuthEdDSAKey returns the cached Ed25519 public key for `kid` from
+// `jwksURL`, fetching the JWKS over HTTP on cache miss.
+func fetchBetterAuthEdDSAKey(jwksURL string, kid string) (ed25519.PublicKey, error) {
+	cacheKey := jwksURL + "|" + kid
+	betterAuthJwksMu.RLock()
+	if k, ok := betterAuthJwksCache[cacheKey]; ok {
+		betterAuthJwksMu.RUnlock()
+		return k, nil
+	}
+	betterAuthJwksMu.RUnlock()
+
+	resp, err := http.Get(jwksURL) // #nosec G107 - JWKS URL is configured by the operator, not an arbitrary token claim.
+	if err != nil {
+		return nil, fmt.Errorf("fetch JWKS: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return nil, fmt.Errorf("fetch JWKS: http %d", resp.StatusCode)
+	}
+
+	var jwks jwkOKPSet
+	if err := json.NewDecoder(resp.Body).Decode(&jwks); err != nil {
+		return nil, fmt.Errorf("decode JWKS: %w", err)
+	}
+
+	for _, k := range jwks.Keys {
+		if k.Kid != kid {
+			continue
+		}
+		if k.Kty != "OKP" || k.Crv != "Ed25519" {
+			return nil, fmt.Errorf("unsupported JWK key type/curve: kty=%s crv=%s (only OKP/Ed25519 supported)", k.Kty, k.Crv)
+		}
+		raw, err := base64.RawURLEncoding.DecodeString(k.X)
+		if err != nil {
+			return nil, fmt.Errorf("decode JWK x: %w", err)
+		}
+		if len(raw) != ed25519.PublicKeySize {
+			return nil, fmt.Errorf("ed25519 public key has unexpected length %d", len(raw))
+		}
+		pub := ed25519.PublicKey(raw)
+
+		betterAuthJwksMu.Lock()
+		betterAuthJwksCache[cacheKey] = pub
+		betterAuthJwksMu.Unlock()
+		return pub, nil
+	}
+	return nil, fmt.Errorf("kid not found in JWKS: %s", kid)
+}
+
+// parseBetterAuthJWT validates `jwtStr` against the JWKS at `jwksURL` and
+// returns the parsed claims. Only EdDSA / Ed25519 is accepted.
+func parseBetterAuthJWT(jwtStr string, jwksURL string) (*BetterAuthJWT, error) {
+	parser := jwtv5.NewParser(jwtv5.WithValidMethods([]string{jwtv5.SigningMethodEdDSA.Alg()}))
+	token, err := parser.Parse(jwtStr, func(t *jwtv5.Token) (interface{}, error) {
+		kidVal, ok := t.Header["kid"]
+		if !ok {
+			return nil, fmt.Errorf("missing kid")
+		}
+		kid, ok := kidVal.(string)
+		if !ok || kid == "" {
+			return nil, fmt.Errorf("invalid kid")
+		}
+		return fetchBetterAuthEdDSAKey(jwksURL, kid)
+	})
+	if err != nil {
+		return nil, fmt.Errorf("parse better-auth jwt: %w", err)
+	}
+
+	mc, ok := token.Claims.(jwtv5.MapClaims)
+	if !ok {
+		return nil, fmt.Errorf("parse better-auth jwt: unexpected claims type")
+	}
+	raw, err := json.Marshal(mc)
+	if err != nil {
+		return nil, fmt.Errorf("marshal claims: %w", err)
+	}
+	var parsed BetterAuthJWT
+	if err := json.Unmarshal(raw, &parsed); err != nil {
+		return nil, fmt.Errorf("unmarshal claims: %w", err)
+	}
+
+	if parsed.ExpiresAt > 0 && time.Now().UTC().Unix() > parsed.ExpiresAt {
+		return nil, fmt.Errorf("better-auth jwt expired")
+	}
+	if strings.TrimSpace(parsed.Subject) == "" {
+		return nil, fmt.Errorf("better-auth jwt missing sub")
+	}
+	return &parsed, nil
+}

--- a/api/better_auth_test.go
+++ b/api/better_auth_test.go
@@ -1,0 +1,135 @@
+package api
+
+import (
+	"crypto/ed25519"
+	"crypto/rand"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	jwtv5 "github.com/golang-jwt/jwt/v5"
+)
+
+// TestParseBetterAuthJWT signs a JWT with a known Ed25519 key, exposes its
+// public half via a fake JWKS endpoint, and verifies parseBetterAuthJWT
+// can validate it end-to-end. This mirrors what Better Auth's JWT plugin
+// does in production.
+func TestParseBetterAuthJWT(t *testing.T) {
+	pub, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("generate key: %v", err)
+	}
+	const kid = "test-kid"
+
+	jwks := jwkOKPSet{
+		Keys: []jwkOKPKey{{
+			Kty: "OKP",
+			Crv: "Ed25519",
+			Use: "sig",
+			Alg: "EdDSA",
+			Kid: kid,
+			X:   base64.RawURLEncoding.EncodeToString(pub),
+		}},
+	}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(jwks)
+	}))
+	defer srv.Close()
+
+	now := time.Now().UTC().Unix()
+	claims := jwtv5.MapClaims{
+		"sub":         "user-123",
+		"id":          "user-123",
+		"email":       "alice@example.com",
+		"phoneNumber": "+15551234567",
+		"name":        "Alice Smith",
+		"iat":         now,
+		"exp":         now + 600,
+		"iss":         "http://localhost:3009",
+		"aud":         "http://localhost:3009",
+	}
+	tok := jwtv5.NewWithClaims(jwtv5.SigningMethodEdDSA, claims)
+	tok.Header["kid"] = kid
+	signed, err := tok.SignedString(priv)
+	if err != nil {
+		t.Fatalf("sign: %v", err)
+	}
+
+	parsed, err := parseBetterAuthJWT(signed, srv.URL)
+	if err != nil {
+		t.Fatalf("parseBetterAuthJWT: %v", err)
+	}
+	if parsed.Subject != "user-123" {
+		t.Errorf("sub: got %q, want user-123", parsed.Subject)
+	}
+	if parsed.Email == nil || *parsed.Email != "alice@example.com" {
+		t.Errorf("email: got %v, want alice@example.com", parsed.Email)
+	}
+	if parsed.PhoneNumber == nil || *parsed.PhoneNumber != "+15551234567" {
+		t.Errorf("phone: got %v", parsed.PhoneNumber)
+	}
+	if parsed.Name != "Alice Smith" {
+		t.Errorf("name: got %q", parsed.Name)
+	}
+}
+
+func TestParseBetterAuthJWT_RejectsHS256(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"keys":[]}`))
+	}))
+	defer srv.Close()
+
+	tok := jwtv5.NewWithClaims(jwtv5.SigningMethodHS256, jwtv5.MapClaims{
+		"sub": "user-123",
+		"exp": time.Now().Add(time.Hour).Unix(),
+	})
+	tok.Header["kid"] = "x"
+	signed, err := tok.SignedString([]byte("secret"))
+	if err != nil {
+		t.Fatalf("sign: %v", err)
+	}
+	if _, err := parseBetterAuthJWT(signed, srv.URL); err == nil {
+		t.Fatal("expected non-EdDSA token to be rejected")
+	}
+}
+
+func TestParseBetterAuthJWT_Expired(t *testing.T) {
+	pub, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("generate key: %v", err)
+	}
+	const kid = "expired-kid"
+	jwks := jwkOKPSet{Keys: []jwkOKPKey{{
+		Kty: "OKP", Crv: "Ed25519", Alg: "EdDSA", Kid: kid,
+		X: base64.RawURLEncoding.EncodeToString(pub),
+	}}}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(jwks)
+	}))
+	defer srv.Close()
+
+	tok := jwtv5.NewWithClaims(jwtv5.SigningMethodEdDSA, jwtv5.MapClaims{
+		"sub": "user-123",
+		"exp": time.Now().Add(-time.Hour).Unix(),
+	})
+	tok.Header["kid"] = kid
+	signed, err := tok.SignedString(priv)
+	if err != nil {
+		t.Fatalf("sign: %v", err)
+	}
+	_, err = parseBetterAuthJWT(signed, srv.URL)
+	if err == nil {
+		t.Fatal("expected expired token to error")
+	}
+	// jwt/v5 returns its own ErrTokenExpired wrapped in our error message;
+	// our explicit `time.Now > exp` check is a backstop.
+	if err == nil {
+		t.Fatal("unreachable")
+	}
+	_ = fmt.Sprintf("%v", err) // suppress unused import warning if changes
+}

--- a/api/better_auth_test.go
+++ b/api/better_auth_test.go
@@ -60,7 +60,7 @@ func TestParseBetterAuthJWT(t *testing.T) {
 		t.Fatalf("sign: %v", err)
 	}
 
-	parsed, err := parseBetterAuthJWT(signed, srv.URL)
+	parsed, err := parseBetterAuthJWT(signed, srv.URL, "http://localhost:3009")
 	if err != nil {
 		t.Fatalf("parseBetterAuthJWT: %v", err)
 	}
@@ -93,7 +93,7 @@ func TestParseBetterAuthJWT_RejectsHS256(t *testing.T) {
 	if err != nil {
 		t.Fatalf("sign: %v", err)
 	}
-	if _, err := parseBetterAuthJWT(signed, srv.URL); err == nil {
+	if _, err := parseBetterAuthJWT(signed, srv.URL, ""); err == nil {
 		t.Fatal("expected non-EdDSA token to be rejected")
 	}
 }
@@ -122,7 +122,7 @@ func TestParseBetterAuthJWT_Expired(t *testing.T) {
 	if err != nil {
 		t.Fatalf("sign: %v", err)
 	}
-	_, err = parseBetterAuthJWT(signed, srv.URL)
+	_, err = parseBetterAuthJWT(signed, srv.URL, "")
 	if err == nil {
 		t.Fatal("expected expired token to error")
 	}
@@ -132,4 +132,34 @@ func TestParseBetterAuthJWT_Expired(t *testing.T) {
 		t.Fatal("unreachable")
 	}
 	_ = fmt.Sprintf("%v", err) // suppress unused import warning if changes
+}
+
+func TestParseBetterAuthJWT_IssuerMismatch(t *testing.T) {
+	pub, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("generate key: %v", err)
+	}
+	const kid = "iss-kid"
+	jwks := jwkOKPSet{Keys: []jwkOKPKey{{
+		Kty: "OKP", Crv: "Ed25519", Alg: "EdDSA", Kid: kid,
+		X: base64.RawURLEncoding.EncodeToString(pub),
+	}}}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(jwks)
+	}))
+	defer srv.Close()
+
+	tok := jwtv5.NewWithClaims(jwtv5.SigningMethodEdDSA, jwtv5.MapClaims{
+		"sub": "user-123",
+		"exp": time.Now().Add(time.Hour).Unix(),
+		"iss": "https://attacker.example.com",
+	})
+	tok.Header["kid"] = kid
+	signed, err := tok.SignedString(priv)
+	if err != nil {
+		t.Fatalf("sign: %v", err)
+	}
+	if _, err := parseBetterAuthJWT(signed, srv.URL, "https://api.factor.trade"); err == nil {
+		t.Fatal("expected issuer-mismatch token to be rejected")
+	}
 }

--- a/auth-service/.dockerignore
+++ b/auth-service/.dockerignore
@@ -1,0 +1,5 @@
+node_modules
+dist
+.env
+.env.local
+*.log

--- a/auth-service/.env.example
+++ b/auth-service/.env.example
@@ -1,43 +1,23 @@
-# Public URL the app is reachable at (used to construct OAuth callback URLs).
-APP_BASE_URL=http://localhost:3009
+# The auth-service almost never needs a .env file. By default it reads
+# secrets (incl. DB credentials) from the project's secrets.json — same
+# pattern as the Go API. Production reads them from Fly secrets via
+# FB_SECRETS_FROM_ENV=1.
+#
+# This file documents the non-secret env vars you might *override* during
+# local development. For the full prod values, see fly.toml's [env] block.
 
-# Path to mount Better Auth at. Default matches the React client default.
-AUTH_BASE_PATH=/api/auth
+# APP_BASE_URL=http://localhost:3009
+# AUTH_INTERNAL_PORT=3001
+# TRUSTED_ORIGINS=http://localhost:3000,http://localhost:3009
 
-# Local port the auth service binds to. Go reverse-proxies /api/auth/* here.
-AUTH_INTERNAL_PORT=3001
+# AUTH_DB_SCHEMA=auth
 
-# Comma-separated. Defaults to APP_BASE_URL if not set.
-TRUSTED_ORIGINS=http://localhost:3000,http://localhost:3009
+# FEATURE_GOOGLE=false       # Default off locally — turn on if you've added
+                             # googleClientId/googleClientSecret to secrets.json.
+# FEATURE_EMAIL_OTP=true
+# FEATURE_SMS_OTP=true
 
-# `openssl rand -hex 32`
-BETTER_AUTH_SECRET=replace-with-32-byte-random-secret-replace-this
+# EMAIL_PROVIDER=console     # `console` prints OTPs to stdout (dev default).
+# SMS_PROVIDER=console       # Set to `resend` / `twilio` only with real creds.
 
-# Connect string for the SHARED postgres. The wrapper appends
-# `?options=-c search_path=auth` automatically based on AUTH_DB_SCHEMA.
-DATABASE_URL=postgres://postgres:postgres@localhost:5440/postgres
-AUTH_DB_SCHEMA=auth
-
-# Feature flags. Default to true; set to false to disable a flow.
-FEATURE_GOOGLE=true
-FEATURE_EMAIL_OTP=true
-FEATURE_SMS_OTP=true
-
-# Required when FEATURE_GOOGLE=true.
-GOOGLE_CLIENT_ID=
-GOOGLE_CLIENT_SECRET=
-
-# Email transport. `console` logs OTPs to stdout (dev only).
-EMAIL_PROVIDER=console
-EMAIL_FROM="Factorbacktest <no-reply@factorbacktest.net>"
-RESEND_API_KEY=
-
-# SMS transport. `console` logs OTPs to stdout (dev only).
-SMS_PROVIDER=console
-SMS_FROM=
-TWILIO_ACCOUNT_SID=
-TWILIO_AUTH_TOKEN=
-TWILIO_MESSAGING_SERVICE_SID=
-
-# Sync hook: mirror Better Auth users into public.app_user_profile.
-APP_USER_SYNC_ENABLED=true
+# APP_USER_SYNC_ENABLED=false

--- a/auth-service/.env.example
+++ b/auth-service/.env.example
@@ -1,0 +1,43 @@
+# Public URL the app is reachable at (used to construct OAuth callback URLs).
+APP_BASE_URL=http://localhost:3009
+
+# Path to mount Better Auth at. Default matches the React client default.
+AUTH_BASE_PATH=/api/auth
+
+# Local port the auth service binds to. Go reverse-proxies /api/auth/* here.
+AUTH_INTERNAL_PORT=3001
+
+# Comma-separated. Defaults to APP_BASE_URL if not set.
+TRUSTED_ORIGINS=http://localhost:3000,http://localhost:3009
+
+# `openssl rand -hex 32`
+BETTER_AUTH_SECRET=replace-with-32-byte-random-secret-replace-this
+
+# Connect string for the SHARED postgres. The wrapper appends
+# `?options=-c search_path=auth` automatically based on AUTH_DB_SCHEMA.
+DATABASE_URL=postgres://postgres:postgres@localhost:5440/postgres
+AUTH_DB_SCHEMA=auth
+
+# Feature flags. Default to true; set to false to disable a flow.
+FEATURE_GOOGLE=true
+FEATURE_EMAIL_OTP=true
+FEATURE_SMS_OTP=true
+
+# Required when FEATURE_GOOGLE=true.
+GOOGLE_CLIENT_ID=
+GOOGLE_CLIENT_SECRET=
+
+# Email transport. `console` logs OTPs to stdout (dev only).
+EMAIL_PROVIDER=console
+EMAIL_FROM="Factorbacktest <no-reply@factorbacktest.net>"
+RESEND_API_KEY=
+
+# SMS transport. `console` logs OTPs to stdout (dev only).
+SMS_PROVIDER=console
+SMS_FROM=
+TWILIO_ACCOUNT_SID=
+TWILIO_AUTH_TOKEN=
+TWILIO_MESSAGING_SERVICE_SID=
+
+# Sync hook: mirror Better Auth users into public.app_user_profile.
+APP_USER_SYNC_ENABLED=true

--- a/auth-service/.gitignore
+++ b/auth-service/.gitignore
@@ -1,0 +1,5 @@
+node_modules/
+dist/
+.env
+.env.local
+*.log

--- a/auth-service/README.md
+++ b/auth-service/README.md
@@ -1,0 +1,59 @@
+# auth-service
+
+Reusable Better Auth service. Mounts at `/api/auth/*`, owns its own
+PostgreSQL schema (`auth` by default), and bridges users to the host app via
+`public.app_user_profile`.
+
+## Layout
+
+```
+auth-service/
+├── auth.ts                 # CLI-discoverable entry: builds betterAuth instance
+├── package.json
+├── tsconfig.json
+├── .env.example
+├── scripts/
+│   ├── bootstrap-schema.sql # CREATE SCHEMA auth + public.app_user_profile
+│   ├── bootstrap.ts         # idempotent runner for bootstrap-schema.sql
+│   └── entrypoint.sh        # bootstrap -> migrate -> serve
+└── src/
+    ├── config.ts            # zod-validated config from env
+    ├── plugins.ts           # emailOTP + phoneNumber + jwt
+    ├── server.ts            # Hono on 127.0.0.1:AUTH_INTERNAL_PORT
+    ├── providers/           # email + sms transports (console / resend / twilio)
+    └── sync/
+        └── app-user-profile.ts  # databaseHooks bridging auth.user -> public
+```
+
+## Local quick start
+
+```bash
+cp .env.example .env
+# edit BETTER_AUTH_SECRET, GOOGLE_*, etc.
+
+npm install
+npm run bootstrap         # CREATE SCHEMA auth + public.app_user_profile
+npm run migrate           # better-auth CLI lays out tables in `auth` schema
+npm run dev               # serves on http://127.0.0.1:3001/api/auth
+```
+
+The default `EMAIL_PROVIDER=console` and `SMS_PROVIDER=console` log OTP codes
+to stdout, so you can do an end-to-end OTP flow without any external accounts.
+
+## Production (inside this repo's Fly app)
+
+The Go API reverse-proxies `/api/auth/*` to `127.0.0.1:3001`, so this service
+binds only to localhost and never sees public traffic directly. See the root
+`Dockerfile.fly` for the multi-stage build that combines Go + Node into a
+single image.
+
+## Reusing in another project
+
+1. Copy this folder.
+2. Adjust `auth.ts` if you want to add/remove plugins.
+3. Adjust `src/sync/app-user-profile.ts` to match the host app's profile table
+   (or set `APP_USER_SYNC_ENABLED=false` and consume `auth.user.id` from JWT
+   claims directly).
+4. Provide env vars per `.env.example`.
+5. Reverse-proxy `/api/auth/*` to this service from your main app (or expose
+   it directly).

--- a/auth-service/README.md
+++ b/auth-service/README.md
@@ -2,7 +2,7 @@
 
 Reusable Better Auth service. Mounts at `/api/auth/*`, owns its own
 PostgreSQL schema (`auth` by default), and bridges users to the host app via
-`public.app_user_profile`.
+`public.app_user_profile` (when enabled).
 
 ## Layout
 
@@ -17,7 +17,8 @@ auth-service/
 │   ├── bootstrap.ts         # idempotent runner for bootstrap-schema.sql
 │   └── entrypoint.sh        # bootstrap -> migrate -> serve
 └── src/
-    ├── config.ts            # zod-validated config from env
+    ├── secrets.ts           # loads secrets from secrets.json or env vars
+    ├── config.ts            # zod-validated non-secret config from env
     ├── plugins.ts           # emailOTP + phoneNumber + jwt
     ├── server.ts            # Hono on 127.0.0.1:AUTH_INTERNAL_PORT
     ├── providers/           # email + sms transports (console / resend / twilio)
@@ -25,35 +26,71 @@ auth-service/
         └── app-user-profile.ts  # databaseHooks bridging auth.user -> public
 ```
 
+## How config + secrets resolve
+
+The auth-service uses the same loading pattern as the Go API:
+
+1. **Secrets** (DB credentials + Better Auth secret + provider API keys):
+   - If `FB_SECRETS_FROM_ENV=1`, read camelCase env vars
+     (`betterAuthSecret`, `host`, `password`, `googleClientSecret`, ...).
+     Same names Fly already uses for the Go side.
+   - Otherwise, walk up looking for `secrets.json` and read its `db` and
+     `auth` sections. See [secrets-test.json](../secrets-test.json) for the
+     shape.
+2. **Non-secret config** (URLs, feature flags, provider names): read from
+   process env with sensible defaults, so a fresh checkout with a populated
+   `secrets.json` "just works" without any extra files. Production
+   overrides live in [fly.toml](../fly.toml)'s `[env]` block.
+
 ## Local quick start
 
-```bash
-cp .env.example .env
-# edit BETTER_AUTH_SECRET, GOOGLE_*, etc.
+Add an `auth` section to your `secrets.json` at the repo root (one-time):
 
-npm install
-npm run bootstrap         # CREATE SCHEMA auth + public.app_user_profile
-npm run migrate           # better-auth CLI lays out tables in `auth` schema
-npm run dev               # serves on http://127.0.0.1:3001/api/auth
+```json
+{
+  ...,
+  "auth": {
+    "betterAuthSecret": "<openssl rand -hex 32>",
+    "googleClientId": "",
+    "googleClientSecret": "",
+    "resendApiKey": "",
+    "twilioAccountSid": "",
+    "twilioAuthToken": ""
+  }
+}
 ```
 
-The default `EMAIL_PROVIDER=console` and `SMS_PROVIDER=console` log OTP codes
-to stdout, so you can do an end-to-end OTP flow without any external accounts.
+Then:
+
+```bash
+cd auth-service
+npm install
+npm run bootstrap   # CREATE SCHEMA auth + public.app_user_profile
+npm run migrate     # better-auth CLI lays out tables in `auth` schema
+npm run dev         # serves on http://127.0.0.1:3001/api/auth
+```
+
+Email and SMS default to the `console` provider, so OTP codes print to
+stdout — you can sign in end-to-end without any external accounts. Google
+defaults to off; flip `FEATURE_GOOGLE=true` (env or fly.toml) once you've
+added real OAuth credentials to `secrets.json`.
 
 ## Production (inside this repo's Fly app)
 
-The Go API reverse-proxies `/api/auth/*` to `127.0.0.1:3001`, so this service
-binds only to localhost and never sees public traffic directly. See the root
-`Dockerfile.fly` for the multi-stage build that combines Go + Node into a
-single image.
+The Go API reverse-proxies `/api/auth/*` to `127.0.0.1:3001`, so this
+service binds only to localhost. The multi-stage `Dockerfile.fly` and
+`scripts/start.sh` supervisor in the repo root run both processes together
+in one Fly machine. See [plans/fly-deployment.md](../plans/fly-deployment.md)
+for the deploy / cutover runbook.
 
 ## Reusing in another project
 
 1. Copy this folder.
 2. Adjust `auth.ts` if you want to add/remove plugins.
-3. Adjust `src/sync/app-user-profile.ts` to match the host app's profile table
-   (or set `APP_USER_SYNC_ENABLED=false` and consume `auth.user.id` from JWT
-   claims directly).
-4. Provide env vars per `.env.example`.
-5. Reverse-proxy `/api/auth/*` to this service from your main app (or expose
-   it directly).
+3. Adjust `src/sync/app-user-profile.ts` to match the host app's profile
+   table (or set `APP_USER_SYNC_ENABLED=false` and consume `auth.user.id`
+   from JWT claims directly).
+4. Either provide a `secrets.json` with `db` + `auth` sections, or set
+   `FB_SECRETS_FROM_ENV=1` and supply the same fields as env vars.
+5. Reverse-proxy `/api/auth/*` to this service from your main app, or
+   expose port 3001 directly.

--- a/auth-service/auth.ts
+++ b/auth-service/auth.ts
@@ -1,0 +1,36 @@
+import { betterAuth } from "better-auth";
+import { Pool } from "pg";
+import { loadConfig } from "./src/config.js";
+import { buildPlugins } from "./src/plugins.js";
+import { buildDatabaseHooks } from "./src/sync/app-user-profile.js";
+
+const config = loadConfig();
+
+export const pool = new Pool({
+  connectionString: config.database.url,
+  max: 10,
+});
+
+const socialProviders = config.google
+  ? {
+      google: {
+        clientId: config.google.clientId,
+        clientSecret: config.google.clientSecret,
+        prompt: "select_account" as const,
+      },
+    }
+  : {};
+
+export const auth = betterAuth({
+  baseURL: config.baseURL,
+  basePath: config.basePath,
+  secret: config.secret,
+  trustedOrigins: config.trustedOrigins,
+  database: pool,
+  emailAndPassword: { enabled: false },
+  socialProviders,
+  plugins: buildPlugins(config),
+  databaseHooks: buildDatabaseHooks({ pool, enabled: config.appUserSync.enabled }),
+});
+
+export { config };

--- a/auth-service/package-lock.json
+++ b/auth-service/package-lock.json
@@ -1,0 +1,2021 @@
+{
+  "name": "auth-service",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "auth-service",
+      "version": "0.1.0",
+      "dependencies": {
+        "@hono/node-server": "^1.13.7",
+        "better-auth": "^1.2.7",
+        "hono": "^4.6.14",
+        "pg": "^8.13.1",
+        "resend": "^4.0.1",
+        "twilio": "^5.4.0",
+        "zod": "^3.24.1"
+      },
+      "devDependencies": {
+        "@types/node": "^22.10.2",
+        "@types/pg": "^8.11.10",
+        "tsx": "^4.19.2",
+        "typescript": "^5.7.2"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@better-auth/utils": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@better-auth/utils/-/utils-0.4.0.tgz",
+      "integrity": "sha512-RpMtLUIQAEWMgdPLNVbIF5ON2mm+CH0U3rCdUCU1VyeAUui4m38DyK7/aXMLZov2YDjG684pS1D0MBllrmgjQA==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "^2.0.1"
+      }
+    },
+    "node_modules/@better-fetch/fetch": {
+      "version": "1.1.21",
+      "resolved": "https://registry.npmjs.org/@better-fetch/fetch/-/fetch-1.1.21.tgz",
+      "integrity": "sha512-/ImESw0sskqlVR94jB+5+Pxjf+xBwDZF/N5+y2/q4EqD7IARUTSpPfIo8uf39SYpCxyOCtbyYpUrZ3F/k0zT4A=="
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.7.tgz",
+      "integrity": "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.7.tgz",
+      "integrity": "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.7.tgz",
+      "integrity": "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.7.tgz",
+      "integrity": "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.7.tgz",
+      "integrity": "sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.7.tgz",
+      "integrity": "sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.7.tgz",
+      "integrity": "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.7.tgz",
+      "integrity": "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.7.tgz",
+      "integrity": "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.7.tgz",
+      "integrity": "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.7.tgz",
+      "integrity": "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.7.tgz",
+      "integrity": "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.7.tgz",
+      "integrity": "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.7.tgz",
+      "integrity": "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.7.tgz",
+      "integrity": "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.7.tgz",
+      "integrity": "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.7.tgz",
+      "integrity": "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.7.tgz",
+      "integrity": "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.7.tgz",
+      "integrity": "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.7.tgz",
+      "integrity": "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.7.tgz",
+      "integrity": "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@hono/node-server": {
+      "version": "1.19.14",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
+      "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.14.1"
+      },
+      "peerDependencies": {
+        "hono": "^4"
+      }
+    },
+    "node_modules/@noble/ciphers": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@noble/ciphers/-/ciphers-2.2.0.tgz",
+      "integrity": "sha512-Z6pjIZ/8IJcCGzb2S/0Px5J81yij85xASuk1teLNeg75bfT07MV3a/O2Mtn1I2se43k3lkVEcFaR10N4cgQcZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@noble/hashes": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.2.0.tgz",
+      "integrity": "sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.40.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.40.0.tgz",
+      "integrity": "sha512-cifvXDhcqMwwTlTK04GBNeIe7yyo28Mfby85QXFe1Yk8nmi36Ab/5UQwptOx84SsoGNRg+EVSjwzfSZMy6pmlw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@react-email/render": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@react-email/render/-/render-1.1.2.tgz",
+      "integrity": "sha512-RnRehYN3v9gVlNMehHPHhyp2RQo7+pSkHDtXPvg3s0GbzM9SQMW4Qrf8GRNvtpLC4gsI+Wt0VatNRUFqjvevbw==",
+      "license": "MIT",
+      "dependencies": {
+        "html-to-text": "^9.0.5",
+        "prettier": "^3.5.3",
+        "react-promise-suspense": "^0.3.4"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "react": "^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^18.0 || ^19.0 || ^19.0.0-rc"
+      }
+    },
+    "node_modules/@selderee/plugin-htmlparser2": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@selderee/plugin-htmlparser2/-/plugin-htmlparser2-0.11.0.tgz",
+      "integrity": "sha512-P33hHGdldxGabLFjPPpaTxVolMrzrcegejx+0GxjrIb9Zv48D8yAIA/QTDR2dFl7Uz7urX8aX6+5bCZslr+gWQ==",
+      "license": "MIT",
+      "dependencies": {
+        "domhandler": "^5.0.3",
+        "selderee": "^0.11.0"
+      },
+      "funding": {
+        "url": "https://ko-fi.com/killymxi"
+      }
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "22.19.17",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.17.tgz",
+      "integrity": "sha512-wGdMcf+vPYM6jikpS/qhg6WiqSV/OhG+jeeHT/KlVqxYfD40iYJf9/AE1uQxVWFvU7MipKRkRv8NSHiCGgPr8Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@types/pg": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/@types/pg/-/pg-8.20.0.tgz",
+      "integrity": "sha512-bEPFOaMAHTEP1EzpvHTbmwR8UsFyHSKsRisLIHVMXnpNefSbGA1bD6CVy+qKjGSqmZqNqBDV2azOBo8TgkcVow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "pg-protocol": "*",
+        "pg-types": "^2.2.0"
+      }
+    },
+    "node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "license": "MIT"
+    },
+    "node_modules/axios": {
+      "version": "1.15.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.2.tgz",
+      "integrity": "sha512-wLrXxPtcrPTsNlJmKjkPnNPK2Ihe0hn0wGSaTEiHRPxwjvJwT3hKmXF4dpqxmPO9SoNb2FsYXj/xEo0gHN+D5A==",
+      "license": "MIT",
+      "dependencies": {
+        "follow-redirects": "^1.15.11",
+        "form-data": "^4.0.5",
+        "proxy-from-env": "^2.1.0"
+      }
+    },
+    "node_modules/better-auth": {
+      "version": "1.6.9",
+      "resolved": "https://registry.npmjs.org/better-auth/-/better-auth-1.6.9.tgz",
+      "integrity": "sha512-EBFURtglyiEZxbx4NJBoqUD8J65dX24yC+6I9AUbIXNgUkt76mshzGbHkxZ3n/lB7Dwq3kBC+hHt0hUQsnL7HA==",
+      "license": "MIT",
+      "dependencies": {
+        "@better-auth/core": "1.6.9",
+        "@better-auth/drizzle-adapter": "1.6.9",
+        "@better-auth/kysely-adapter": "1.6.9",
+        "@better-auth/memory-adapter": "1.6.9",
+        "@better-auth/mongo-adapter": "1.6.9",
+        "@better-auth/prisma-adapter": "1.6.9",
+        "@better-auth/telemetry": "1.6.9",
+        "@better-auth/utils": "0.4.0",
+        "@better-fetch/fetch": "1.1.21",
+        "@noble/ciphers": "^2.1.1",
+        "@noble/hashes": "^2.0.1",
+        "better-call": "1.3.5",
+        "defu": "^6.1.4",
+        "jose": "^6.1.3",
+        "kysely": "^0.28.14",
+        "nanostores": "^1.1.1",
+        "zod": "^4.3.6"
+      },
+      "peerDependencies": {
+        "@lynx-js/react": "*",
+        "@prisma/client": "^5.0.0 || ^6.0.0 || ^7.0.0",
+        "@sveltejs/kit": "^2.0.0",
+        "@tanstack/react-start": "^1.0.0",
+        "@tanstack/solid-start": "^1.0.0",
+        "better-sqlite3": "^12.0.0",
+        "drizzle-kit": ">=0.31.4",
+        "drizzle-orm": "^0.45.2",
+        "mongodb": "^6.0.0 || ^7.0.0",
+        "mysql2": "^3.0.0",
+        "next": "^14.0.0 || ^15.0.0 || ^16.0.0",
+        "pg": "^8.0.0",
+        "prisma": "^5.0.0 || ^6.0.0 || ^7.0.0",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0",
+        "solid-js": "^1.0.0",
+        "svelte": "^4.0.0 || ^5.0.0",
+        "vitest": "^2.0.0 || ^3.0.0 || ^4.0.0",
+        "vue": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@lynx-js/react": {
+          "optional": true
+        },
+        "@prisma/client": {
+          "optional": true
+        },
+        "@sveltejs/kit": {
+          "optional": true
+        },
+        "@tanstack/react-start": {
+          "optional": true
+        },
+        "@tanstack/solid-start": {
+          "optional": true
+        },
+        "better-sqlite3": {
+          "optional": true
+        },
+        "drizzle-kit": {
+          "optional": true
+        },
+        "drizzle-orm": {
+          "optional": true
+        },
+        "mongodb": {
+          "optional": true
+        },
+        "mysql2": {
+          "optional": true
+        },
+        "next": {
+          "optional": true
+        },
+        "pg": {
+          "optional": true
+        },
+        "prisma": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        },
+        "solid-js": {
+          "optional": true
+        },
+        "svelte": {
+          "optional": true
+        },
+        "vitest": {
+          "optional": true
+        },
+        "vue": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/better-auth/node_modules/@better-auth/core": {
+      "version": "1.6.9",
+      "resolved": "https://registry.npmjs.org/@better-auth/core/-/core-1.6.9.tgz",
+      "integrity": "sha512-ADFk5pwmLybmc+LvYvXJ6M1x2oY/EyYLkwLuH0x28FUq12DfjL0wnE7g+WRDf3yozDO+qIxTpFGXDGwLKbfz0w==",
+      "license": "MIT",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "^1.39.0",
+        "@standard-schema/spec": "^1.1.0",
+        "zod": "^4.3.6"
+      },
+      "peerDependencies": {
+        "@better-auth/utils": "0.4.0",
+        "@better-fetch/fetch": "1.1.21",
+        "@cloudflare/workers-types": ">=4",
+        "@opentelemetry/api": "^1.9.0",
+        "better-call": "1.3.5",
+        "jose": "^6.1.0",
+        "kysely": "^0.28.5",
+        "nanostores": "^1.0.1"
+      },
+      "peerDependenciesMeta": {
+        "@cloudflare/workers-types": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/better-auth/node_modules/@better-auth/drizzle-adapter": {
+      "version": "1.6.9",
+      "resolved": "https://registry.npmjs.org/@better-auth/drizzle-adapter/-/drizzle-adapter-1.6.9.tgz",
+      "integrity": "sha512-Lcco5hOGrMgc4XKAkvB6x72eQm4wCcya8IevMg4wBHY9W9GVg8pu23rpRX6VsVQSO4Ux13S7lFwUWtF7/r9aKw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@better-auth/core": "^1.6.9",
+        "@better-auth/utils": "0.4.0",
+        "drizzle-orm": "^0.45.2"
+      },
+      "peerDependenciesMeta": {
+        "drizzle-orm": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/better-auth/node_modules/@better-auth/kysely-adapter": {
+      "version": "1.6.9",
+      "resolved": "https://registry.npmjs.org/@better-auth/kysely-adapter/-/kysely-adapter-1.6.9.tgz",
+      "integrity": "sha512-gyjuuxJtZ4o9G9z9q4kqn24X2kvMSp7F+KHogYxF03SnXY/2WleAcuj57iC4wP3e9mGDbjPOrnM5K6Kr3Ktdpw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@better-auth/core": "^1.6.9",
+        "@better-auth/utils": "0.4.0",
+        "kysely": "^0.28.14"
+      },
+      "peerDependenciesMeta": {
+        "kysely": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/better-auth/node_modules/@better-auth/memory-adapter": {
+      "version": "1.6.9",
+      "resolved": "https://registry.npmjs.org/@better-auth/memory-adapter/-/memory-adapter-1.6.9.tgz",
+      "integrity": "sha512-XmIG4tUnOXZ+KEcWjHUjOI9Z5donD09dC2t/AQTXifAUIqx7cySg86w0KTM09ArzAxRx1fCqO36Wkt5nULnrkQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@better-auth/core": "^1.6.9",
+        "@better-auth/utils": "0.4.0"
+      }
+    },
+    "node_modules/better-auth/node_modules/@better-auth/mongo-adapter": {
+      "version": "1.6.9",
+      "resolved": "https://registry.npmjs.org/@better-auth/mongo-adapter/-/mongo-adapter-1.6.9.tgz",
+      "integrity": "sha512-h+AiRJ/TsBSi+ZDjySASBpbJ/9QCXBre34PSKgCz7QmTHrFM9Cg2EM4AM7LjR5lPXipEE+2rWPBc9wfnUBjhcw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@better-auth/core": "^1.6.9",
+        "@better-auth/utils": "0.4.0",
+        "mongodb": "^6.0.0 || ^7.0.0"
+      },
+      "peerDependenciesMeta": {
+        "mongodb": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/better-auth/node_modules/@better-auth/prisma-adapter": {
+      "version": "1.6.9",
+      "resolved": "https://registry.npmjs.org/@better-auth/prisma-adapter/-/prisma-adapter-1.6.9.tgz",
+      "integrity": "sha512-XHks01ntK20orqK/jICq8wmEbJ/zT6dct49Fk8zTQKN9QNGDc+Ix5+7z/Kvui0DXGFf790GfvRozquzaLtXa8Q==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@better-auth/core": "^1.6.9",
+        "@better-auth/utils": "0.4.0",
+        "@prisma/client": "^5.0.0 || ^6.0.0 || ^7.0.0",
+        "prisma": "^5.0.0 || ^6.0.0 || ^7.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@prisma/client": {
+          "optional": true
+        },
+        "prisma": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/better-auth/node_modules/@better-auth/telemetry": {
+      "version": "1.6.9",
+      "resolved": "https://registry.npmjs.org/@better-auth/telemetry/-/telemetry-1.6.9.tgz",
+      "integrity": "sha512-0u5zkhSCAQFoN3DHvUkLHOF6MBbVTDAa6mU8mhPwiysdz1x21vMzhzfaAKN/ZGWaQ09v91/F+2qu42G/bhUV4A==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@better-auth/core": "^1.6.9",
+        "@better-auth/utils": "0.4.0",
+        "@better-fetch/fetch": "1.1.21"
+      }
+    },
+    "node_modules/better-auth/node_modules/better-call": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/better-call/-/better-call-1.3.5.tgz",
+      "integrity": "sha512-kOFJkBP7utAQLEYrobZm3vkTH8mXq5GNgvjc5/XEST1ilVHaxXUXfeDeFlqoETMtyqS4+3/h4ONX2i++ebZrvA==",
+      "license": "MIT",
+      "dependencies": {
+        "@better-auth/utils": "^0.4.0",
+        "@better-fetch/fetch": "^1.1.21",
+        "rou3": "^0.7.12",
+        "set-cookie-parser": "^3.0.1"
+      },
+      "peerDependencies": {
+        "zod": "^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "zod": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/better-auth/node_modules/zod": {
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
+      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/dayjs": {
+      "version": "1.11.20",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.20.tgz",
+      "integrity": "sha512-YbwwqR/uYpeoP4pu043q+LTDLFBLApUP6VxRihdfNTqu4ubqMlGDLd6ErXhEgsyvY0K6nCs7nggYumAN+9uEuQ==",
+      "license": "MIT"
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/deepmerge": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
+      "integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/defu": {
+      "version": "6.1.7",
+      "resolved": "https://registry.npmjs.org/defu/-/defu-6.1.7.tgz",
+      "integrity": "sha512-7z22QmUWiQ/2d0KkdYmANbRUVABpZ9SNYyH5vx6PZ+nE5bcC0l7uFvEfHlyld/HcGBFTL536ClDt3DEcSlEJAQ==",
+      "license": "MIT"
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/dom-serializer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
+      "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.2",
+        "entities": "^4.2.0"
+      },
+      "funding": {
+        "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
+      }
+    },
+    "node_modules/domelementtype": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
+      "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/domhandler": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
+      "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "domelementtype": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 4"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domhandler?sponsor=1"
+      }
+    },
+    "node_modules/domutils": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.2.2.tgz",
+      "integrity": "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "dom-serializer": "^2.0.0",
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domutils?sponsor=1"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.7.tgz",
+      "integrity": "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.27.7",
+        "@esbuild/android-arm": "0.27.7",
+        "@esbuild/android-arm64": "0.27.7",
+        "@esbuild/android-x64": "0.27.7",
+        "@esbuild/darwin-arm64": "0.27.7",
+        "@esbuild/darwin-x64": "0.27.7",
+        "@esbuild/freebsd-arm64": "0.27.7",
+        "@esbuild/freebsd-x64": "0.27.7",
+        "@esbuild/linux-arm": "0.27.7",
+        "@esbuild/linux-arm64": "0.27.7",
+        "@esbuild/linux-ia32": "0.27.7",
+        "@esbuild/linux-loong64": "0.27.7",
+        "@esbuild/linux-mips64el": "0.27.7",
+        "@esbuild/linux-ppc64": "0.27.7",
+        "@esbuild/linux-riscv64": "0.27.7",
+        "@esbuild/linux-s390x": "0.27.7",
+        "@esbuild/linux-x64": "0.27.7",
+        "@esbuild/netbsd-arm64": "0.27.7",
+        "@esbuild/netbsd-x64": "0.27.7",
+        "@esbuild/openbsd-arm64": "0.27.7",
+        "@esbuild/openbsd-x64": "0.27.7",
+        "@esbuild/openharmony-arm64": "0.27.7",
+        "@esbuild/sunos-x64": "0.27.7",
+        "@esbuild/win32-arm64": "0.27.7",
+        "@esbuild/win32-ia32": "0.27.7",
+        "@esbuild/win32-x64": "0.27.7"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
+      "integrity": "sha512-bCK/2Z4zLidyB4ReuIsvALH6w31YfAQDmXMqMx6FyfHqvBxtjC0eRumeSu4Bs3XtXwpyIywtSTrVT99BxY1f9w==",
+      "license": "MIT"
+    },
+    "node_modules/follow-redirects": {
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
+      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/get-tsconfig": {
+      "version": "4.14.0",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.14.0.tgz",
+      "integrity": "sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "resolve-pkg-maps": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz",
+      "integrity": "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/hono": {
+      "version": "4.12.15",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.15.tgz",
+      "integrity": "sha512-qM0jDhFEaCBb4TxoW7f53Qrpv9RBiayUHo0S52JudprkhvpjIrGoU1mnnr29Fvd1U335ZFPZQY1wlkqgfGXyLg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.9.0"
+      }
+    },
+    "node_modules/html-to-text": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/html-to-text/-/html-to-text-9.0.5.tgz",
+      "integrity": "sha512-qY60FjREgVZL03vJU6IfMV4GDjGBIoOyvuFdpBDIX9yTlDw0TjxVBQp+P8NvpdIXNJvfWBTNul7fsAQJq2FNpg==",
+      "license": "MIT",
+      "dependencies": {
+        "@selderee/plugin-htmlparser2": "^0.11.0",
+        "deepmerge": "^4.3.1",
+        "dom-serializer": "^2.0.0",
+        "htmlparser2": "^8.0.2",
+        "selderee": "^0.11.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/htmlparser2": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-8.0.2.tgz",
+      "integrity": "sha512-GYdjWKDkbRLkZ5geuHs5NY1puJ+PXwP7+fHPRz06Eirsb9ugf6d8kkXav6ADhcODhFFPMIXyxkxSuMf3D6NCFA==",
+      "funding": [
+        "https://github.com/fb55/htmlparser2?sponsor=1",
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.0.1",
+        "entities": "^4.4.0"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/jose": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.2.tgz",
+      "integrity": "sha512-d7kPDd34KO/YnzaDOlikGpOurfF0ByC2sEV4cANCtdqLlTfBlw2p14O/5d/zv40gJPbIQxfES3nSx1/oYNyuZQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
+    "node_modules/jsonwebtoken": {
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.3.tgz",
+      "integrity": "sha512-MT/xP0CrubFRNLNKvxJ2BYfy53Zkm++5bX9dtuPbqAeQpTVe0MQTFhao8+Cp//EmJp244xt6Drw/GVEGCUj40g==",
+      "license": "MIT",
+      "dependencies": {
+        "jws": "^4.0.1",
+        "lodash.includes": "^4.3.0",
+        "lodash.isboolean": "^3.0.3",
+        "lodash.isinteger": "^4.0.4",
+        "lodash.isnumber": "^3.0.3",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.isstring": "^4.0.1",
+        "lodash.once": "^4.0.0",
+        "ms": "^2.1.1",
+        "semver": "^7.5.4"
+      },
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      }
+    },
+    "node_modules/jwa": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
+      "integrity": "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-equal-constant-time": "^1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/jws": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.1.tgz",
+      "integrity": "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==",
+      "license": "MIT",
+      "dependencies": {
+        "jwa": "^2.0.1",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/kysely": {
+      "version": "0.28.16",
+      "resolved": "https://registry.npmjs.org/kysely/-/kysely-0.28.16.tgz",
+      "integrity": "sha512-3i5pmOiZvMDj00qhrIVbH0AnioVTx22DMP7Vn5At4yJO46iy+FM8Y/g61ltenLVSo3fiO8h8Q3QOFgf/gQ72ww==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/leac": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/leac/-/leac-0.6.0.tgz",
+      "integrity": "sha512-y+SqErxb8h7nE/fiEX07jsbuhrpO9lL8eca7/Y1nuWV2moNlXhyd59iDGcRf6moVyDMbmTNzL40SUyrFU/yDpg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://ko-fi.com/killymxi"
+      }
+    },
+    "node_modules/lodash.includes": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
+      "integrity": "sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isboolean": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
+      "integrity": "sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isinteger": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
+      "integrity": "sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isnumber": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
+      "integrity": "sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isplainobject": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isstring": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
+      "integrity": "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.once": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
+      "integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==",
+      "license": "MIT"
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/nanostores": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/nanostores/-/nanostores-1.3.0.tgz",
+      "integrity": "sha512-XPUa/jz+P1oJvN9VBxw4L9MtdFfaH3DAryqPssqhb2kXjmb9npz0dly6rCsgFWOPr4Yg9mTfM3MDZgZZ+7A3lA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": "^20.0.0 || >=22.0.0"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/parseley": {
+      "version": "0.12.1",
+      "resolved": "https://registry.npmjs.org/parseley/-/parseley-0.12.1.tgz",
+      "integrity": "sha512-e6qHKe3a9HWr0oMRVDTRhKce+bRO8VGQR3NyVwcjwrbhMmFCX9KszEV35+rn4AdilFAq9VPxP/Fe1wC9Qjd2lw==",
+      "license": "MIT",
+      "dependencies": {
+        "leac": "^0.6.0",
+        "peberminta": "^0.9.0"
+      },
+      "funding": {
+        "url": "https://ko-fi.com/killymxi"
+      }
+    },
+    "node_modules/peberminta": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/peberminta/-/peberminta-0.9.0.tgz",
+      "integrity": "sha512-XIxfHpEuSJbITd1H3EeQwpcZbTLHc+VVr8ANI9t5sit565tsI4/xK3KWTUFE2e6QiangUkh3B0jihzmGnNrRsQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://ko-fi.com/killymxi"
+      }
+    },
+    "node_modules/pg": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/pg/-/pg-8.20.0.tgz",
+      "integrity": "sha512-ldhMxz2r8fl/6QkXnBD3CR9/xg694oT6DZQ2s6c/RI28OjtSOpxnPrUCGOBJ46RCUxcWdx3p6kw/xnDHjKvaRA==",
+      "license": "MIT",
+      "dependencies": {
+        "pg-connection-string": "^2.12.0",
+        "pg-pool": "^3.13.0",
+        "pg-protocol": "^1.13.0",
+        "pg-types": "2.2.0",
+        "pgpass": "1.0.5"
+      },
+      "engines": {
+        "node": ">= 16.0.0"
+      },
+      "optionalDependencies": {
+        "pg-cloudflare": "^1.3.0"
+      },
+      "peerDependencies": {
+        "pg-native": ">=3.0.1"
+      },
+      "peerDependenciesMeta": {
+        "pg-native": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/pg-cloudflare": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/pg-cloudflare/-/pg-cloudflare-1.3.0.tgz",
+      "integrity": "sha512-6lswVVSztmHiRtD6I8hw4qP/nDm1EJbKMRhf3HCYaqud7frGysPv7FYJ5noZQdhQtN2xJnimfMtvQq21pdbzyQ==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/pg-connection-string": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.12.0.tgz",
+      "integrity": "sha512-U7qg+bpswf3Cs5xLzRqbXbQl85ng0mfSV/J0nnA31MCLgvEaAo7CIhmeyrmJpOr7o+zm0rXK+hNnT5l9RHkCkQ==",
+      "license": "MIT"
+    },
+    "node_modules/pg-int8": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/pg-int8/-/pg-int8-1.0.1.tgz",
+      "integrity": "sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/pg-pool": {
+      "version": "3.13.0",
+      "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-3.13.0.tgz",
+      "integrity": "sha512-gB+R+Xud1gLFuRD/QgOIgGOBE2KCQPaPwkzBBGC9oG69pHTkhQeIuejVIk3/cnDyX39av2AxomQiyPT13WKHQA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "pg": ">=8.0"
+      }
+    },
+    "node_modules/pg-protocol": {
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.13.0.tgz",
+      "integrity": "sha512-zzdvXfS6v89r6v7OcFCHfHlyG/wvry1ALxZo4LqgUoy7W9xhBDMaqOuMiF3qEV45VqsN6rdlcehHrfDtlCPc8w==",
+      "license": "MIT"
+    },
+    "node_modules/pg-types": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/pg-types/-/pg-types-2.2.0.tgz",
+      "integrity": "sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==",
+      "license": "MIT",
+      "dependencies": {
+        "pg-int8": "1.0.1",
+        "postgres-array": "~2.0.0",
+        "postgres-bytea": "~1.0.0",
+        "postgres-date": "~1.0.4",
+        "postgres-interval": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/pgpass": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/pgpass/-/pgpass-1.0.5.tgz",
+      "integrity": "sha512-FdW9r/jQZhSeohs1Z3sI1yxFQNFvMcnmfuj4WBMUTxOrAyLMaTcE1aAMBiTlbMNaXvBCQuVi0R7hd8udDSP7ug==",
+      "license": "MIT",
+      "dependencies": {
+        "split2": "^4.1.0"
+      }
+    },
+    "node_modules/postgres-array": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-2.0.0.tgz",
+      "integrity": "sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/postgres-bytea": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/postgres-bytea/-/postgres-bytea-1.0.1.tgz",
+      "integrity": "sha512-5+5HqXnsZPE65IJZSMkZtURARZelel2oXUEO8rH83VS/hxH5vv1uHquPg5wZs8yMAfdv971IU+kcPUczi7NVBQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postgres-date": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/postgres-date/-/postgres-date-1.0.7.tgz",
+      "integrity": "sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postgres-interval": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/postgres-interval/-/postgres-interval-1.2.0.tgz",
+      "integrity": "sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "xtend": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "3.8.3",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.3.tgz",
+      "integrity": "sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==",
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+      "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.15.1",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.1.tgz",
+      "integrity": "sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/react": {
+      "version": "19.2.5",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.5.tgz",
+      "integrity": "sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-dom": {
+      "version": "19.2.5",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.5.tgz",
+      "integrity": "sha512-J5bAZz+DXMMwW/wV3xzKke59Af6CHY7G4uYLN1OvBcKEsWOs4pQExj86BBKamxl/Ik5bx9whOrvBlSDfWzgSag==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "scheduler": "^0.27.0"
+      },
+      "peerDependencies": {
+        "react": "^19.2.5"
+      }
+    },
+    "node_modules/react-promise-suspense": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/react-promise-suspense/-/react-promise-suspense-0.3.4.tgz",
+      "integrity": "sha512-I42jl7L3Ze6kZaq+7zXWSunBa3b1on5yfvUW6Eo/3fFOj6dZ5Bqmcd264nJbTK/gn1HjjILAjSwnZbV4RpSaNQ==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^2.0.1"
+      }
+    },
+    "node_modules/resend": {
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/resend/-/resend-4.8.0.tgz",
+      "integrity": "sha512-R8eBOFQDO6dzRTDmaMEdpqrkmgSjPpVXt4nGfWsZdYOet0kqra0xgbvTES6HmCriZEXbmGk3e0DiGIaLFTFSHA==",
+      "license": "MIT",
+      "dependencies": {
+        "@react-email/render": "1.1.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/resolve-pkg-maps": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
+      "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+      }
+    },
+    "node_modules/rou3": {
+      "version": "0.7.12",
+      "resolved": "https://registry.npmjs.org/rou3/-/rou3-0.7.12.tgz",
+      "integrity": "sha512-iFE4hLDuloSWcD7mjdCDhx2bKcIsYbtOTpfH5MHHLSKMOUyjqQXTeZVa289uuwEGEKFoE/BAPbhaU4B774nceg==",
+      "license": "MIT"
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/scheduler": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
+      "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/scmp": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/scmp/-/scmp-2.1.0.tgz",
+      "integrity": "sha512-o/mRQGk9Rcer/jEEw/yw4mwo3EU/NvYvp577/Btqrym9Qy5/MdWGBqipbALgd2lrdWTJ5/gqDusxfnQBxOxT2Q==",
+      "deprecated": "Just use Node.js's crypto.timingSafeEqual()",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/selderee": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/selderee/-/selderee-0.11.0.tgz",
+      "integrity": "sha512-5TF+l7p4+OsnP8BCCvSyZiSPc4x4//p5uPwK8TCnVPJYRmU2aYKMpOXvw8zM5a5JvuuCGN1jmsMwuU2W02ukfA==",
+      "license": "MIT",
+      "dependencies": {
+        "parseley": "^0.12.0"
+      },
+      "funding": {
+        "url": "https://ko-fi.com/killymxi"
+      }
+    },
+    "node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/set-cookie-parser": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-3.1.0.tgz",
+      "integrity": "sha512-kjnC1DXBHcxaOaOXBHBeRtltsDG2nUiUni+jP92M9gYdW12rsmx92UsfpH7o5tDRs7I1ZZPSQJQGv3UaRfCiuw==",
+      "license": "MIT"
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
+      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3",
+        "side-channel-list": "^1.0.0",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/split2": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
+      "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">= 10.x"
+      }
+    },
+    "node_modules/tsx": {
+      "version": "4.21.0",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.21.0.tgz",
+      "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.27.0",
+        "get-tsconfig": "^4.7.5"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/twilio": {
+      "version": "5.13.1",
+      "resolved": "https://registry.npmjs.org/twilio/-/twilio-5.13.1.tgz",
+      "integrity": "sha512-sT+PkhptF4Mf7t8eXFFvPQx4w5VHnBIPXbltGPMFRe+R2GxfRdMuFbuNA/cEm0aQR6LFQOn33+fhClg+TjRVqQ==",
+      "license": "MIT",
+      "dependencies": {
+        "axios": "^1.13.5",
+        "dayjs": "^1.11.9",
+        "https-proxy-agent": "^5.0.0",
+        "jsonwebtoken": "^9.0.3",
+        "qs": "^6.14.1",
+        "scmp": "^2.1.0",
+        "xmlbuilder": "^13.0.2"
+      },
+      "engines": {
+        "node": ">=14.0"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/xmlbuilder": {
+      "version": "13.0.2",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-13.0.2.tgz",
+      "integrity": "sha512-Eux0i2QdDYKbdbA6AM6xE4m6ZTZr4G4xF9kahI2ukSEMCzwce2eX9WlTI5J3s+NU7hpasFsr8hWIONae7LluAQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0"
+      }
+    },
+    "node_modules/xtend": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4"
+      }
+    },
+    "node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    }
+  }
+}

--- a/auth-service/package.json
+++ b/auth-service/package.json
@@ -1,0 +1,33 @@
+{
+  "name": "auth-service",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Reusable Better Auth service. Mount under /api/auth and share Postgres in a dedicated `auth` schema.",
+  "type": "module",
+  "engines": {
+    "node": ">=20"
+  },
+  "scripts": {
+    "dev": "tsx watch src/server.ts",
+    "build": "tsc -p tsconfig.json",
+    "start": "node dist/server.js",
+    "bootstrap": "tsx scripts/bootstrap.ts",
+    "migrate": "npx --yes @better-auth/cli@latest migrate --yes --config ./auth.ts",
+    "generate": "npx --yes @better-auth/cli@latest generate --yes --config ./auth.ts"
+  },
+  "dependencies": {
+    "@hono/node-server": "^1.13.7",
+    "better-auth": "^1.2.7",
+    "hono": "^4.6.14",
+    "pg": "^8.13.1",
+    "resend": "^4.0.1",
+    "twilio": "^5.4.0",
+    "zod": "^3.24.1"
+  },
+  "devDependencies": {
+    "@types/node": "^22.10.2",
+    "@types/pg": "^8.11.10",
+    "tsx": "^4.19.2",
+    "typescript": "^5.7.2"
+  }
+}

--- a/auth-service/package.json
+++ b/auth-service/package.json
@@ -12,12 +12,12 @@
     "build": "tsc -p tsconfig.json",
     "start": "node dist/server.js",
     "bootstrap": "tsx scripts/bootstrap.ts",
-    "migrate": "npx --yes @better-auth/cli@latest migrate --yes --config ./auth.ts",
-    "generate": "npx --yes @better-auth/cli@latest generate --yes --config ./auth.ts"
+    "migrate": "npx --yes @better-auth/cli@1.6.9 migrate --yes --config ./auth.ts",
+    "generate": "npx --yes @better-auth/cli@1.6.9 generate --yes --config ./auth.ts"
   },
   "dependencies": {
     "@hono/node-server": "^1.13.7",
-    "better-auth": "^1.2.7",
+    "better-auth": "^1.6.9",
     "hono": "^4.6.14",
     "pg": "^8.13.1",
     "resend": "^4.0.1",

--- a/auth-service/scripts/bootstrap-schema.sql
+++ b/auth-service/scripts/bootstrap-schema.sql
@@ -1,0 +1,24 @@
+-- Idempotent bootstrap for the Better Auth schema.
+-- Safe to run on every container start.
+--
+-- Better Auth then creates/updates its own tables inside this schema via
+-- `npx better-auth migrate` (Kysely adapter, search_path-aware).
+
+CREATE SCHEMA IF NOT EXISTS auth;
+
+-- Cross-schema bridge: app-owned profile keyed by Better Auth user id.
+-- Lives in `public` so the Go API and existing app code can join against it
+-- without ever touching `auth.user` directly.
+CREATE TABLE IF NOT EXISTS public.app_user_profile (
+    auth_user_id  TEXT PRIMARY KEY,
+    email         TEXT,
+    display_name  TEXT,
+    phone_number  TEXT,
+    created_at    TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at    TIMESTAMPTZ
+);
+
+CREATE INDEX IF NOT EXISTS app_user_profile_email_idx
+    ON public.app_user_profile (email);
+CREATE INDEX IF NOT EXISTS app_user_profile_phone_idx
+    ON public.app_user_profile (phone_number);

--- a/auth-service/scripts/bootstrap.ts
+++ b/auth-service/scripts/bootstrap.ts
@@ -1,0 +1,49 @@
+import { Client } from "pg";
+import { loadConfig } from "../src/config.js";
+
+// Inlined so the compiled JS doesn't need a sibling .sql file at runtime.
+// Mirrors scripts/bootstrap-schema.sql (kept in the repo as documentation).
+const BOOTSTRAP_SQL = `
+CREATE SCHEMA IF NOT EXISTS "__SCHEMA__";
+
+CREATE TABLE IF NOT EXISTS public.app_user_profile (
+    auth_user_id  TEXT PRIMARY KEY,
+    email         TEXT,
+    display_name  TEXT,
+    phone_number  TEXT,
+    created_at    TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at    TIMESTAMPTZ
+);
+
+CREATE INDEX IF NOT EXISTS app_user_profile_email_idx
+    ON public.app_user_profile (email);
+CREATE INDEX IF NOT EXISTS app_user_profile_phone_idx
+    ON public.app_user_profile (phone_number);
+`;
+
+const main = async () => {
+  const config = loadConfig();
+
+  const adminUrl = new URL(config.database.url);
+  adminUrl.searchParams.delete("options");
+
+  const schema = config.database.schema;
+  if (!/^[a-zA-Z_][a-zA-Z0-9_]*$/.test(schema)) {
+    throw new Error(`unsafe schema name: ${schema}`);
+  }
+  const sql = BOOTSTRAP_SQL.replace("__SCHEMA__", schema);
+
+  const client = new Client({ connectionString: adminUrl.toString() });
+  await client.connect();
+  try {
+    await client.query(sql);
+    console.log(`[bootstrap] ensured schema "${schema}" + public.app_user_profile exist`);
+  } finally {
+    await client.end();
+  }
+};
+
+main().catch((err) => {
+  console.error("[bootstrap] failed", err);
+  process.exit(1);
+});

--- a/auth-service/scripts/entrypoint.sh
+++ b/auth-service/scripts/entrypoint.sh
@@ -5,7 +5,9 @@ echo "[auth-service] running bootstrap"
 node dist/scripts/bootstrap.js
 
 echo "[auth-service] running better-auth migrations"
-npx --yes @better-auth/cli@latest migrate --yes --config ./auth.ts
+# Use the compiled JS so this works in dist-only runtime images. Pinned
+# version mirrors what scripts/start.sh uses in the production Fly image.
+npx --yes @better-auth/cli@1.6.9 migrate --yes --config ./dist/auth.js
 
 echo "[auth-service] starting server"
 exec node dist/src/server.js

--- a/auth-service/scripts/entrypoint.sh
+++ b/auth-service/scripts/entrypoint.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env sh
+set -e
+
+echo "[auth-service] running bootstrap"
+node dist/scripts/bootstrap.js
+
+echo "[auth-service] running better-auth migrations"
+npx --yes @better-auth/cli@latest migrate --yes --config ./auth.ts
+
+echo "[auth-service] starting server"
+exec node dist/src/server.js

--- a/auth-service/src/config.ts
+++ b/auth-service/src/config.ts
@@ -62,6 +62,7 @@ export interface AuthConfig {
       accountSid: string;
       authToken: string;
       messagingServiceSid?: string;
+      verifyServiceSid?: string;
     };
   };
   appUserSync: {
@@ -140,6 +141,7 @@ export const loadConfig = (): AuthConfig => {
               accountSid: secrets.auth.twilioAccountSid,
               authToken: secrets.auth.twilioAuthToken,
               messagingServiceSid: env.TWILIO_MESSAGING_SERVICE_SID,
+              verifyServiceSid: secrets.auth.twilioVerifyServiceSid,
             }
           : undefined,
     },

--- a/auth-service/src/config.ts
+++ b/auth-service/src/config.ts
@@ -1,0 +1,169 @@
+import { z } from "zod";
+
+const featureFlag = (raw: string | undefined, fallback: boolean): boolean => {
+  if (raw === undefined) return fallback;
+  return ["1", "true", "yes", "on"].includes(raw.toLowerCase());
+};
+
+const envSchema = z.object({
+  APP_BASE_URL: z.string().url(),
+  AUTH_BASE_PATH: z.string().default("/api/auth"),
+  AUTH_INTERNAL_PORT: z.coerce.number().int().default(3001),
+  TRUSTED_ORIGINS: z.string().optional(),
+
+  BETTER_AUTH_SECRET: z.string().min(32, "BETTER_AUTH_SECRET must be at least 32 chars"),
+
+  DATABASE_URL: z.string().url(),
+  AUTH_DB_SCHEMA: z.string().default("auth"),
+
+  FEATURE_GOOGLE: z.string().optional(),
+  FEATURE_EMAIL_OTP: z.string().optional(),
+  FEATURE_SMS_OTP: z.string().optional(),
+
+  GOOGLE_CLIENT_ID: z.string().optional(),
+  GOOGLE_CLIENT_SECRET: z.string().optional(),
+
+  EMAIL_PROVIDER: z.enum(["console", "resend"]).default("console"),
+  EMAIL_FROM: z.string().optional(),
+  RESEND_API_KEY: z.string().optional(),
+
+  SMS_PROVIDER: z.enum(["console", "twilio"]).default("console"),
+  SMS_FROM: z.string().optional(),
+  TWILIO_ACCOUNT_SID: z.string().optional(),
+  TWILIO_AUTH_TOKEN: z.string().optional(),
+  TWILIO_MESSAGING_SERVICE_SID: z.string().optional(),
+
+  APP_USER_SYNC_ENABLED: z.string().optional(),
+});
+
+export type AuthEnv = z.infer<typeof envSchema>;
+
+export interface AuthConfig {
+  baseURL: string;
+  basePath: string;
+  internalPort: number;
+  secret: string;
+  trustedOrigins: string[];
+  database: {
+    url: string;
+    schema: string;
+  };
+  features: {
+    google: boolean;
+    emailOtp: boolean;
+    smsOtp: boolean;
+  };
+  google?: {
+    clientId: string;
+    clientSecret: string;
+  };
+  email: {
+    provider: "console" | "resend";
+    from: string;
+    resendApiKey?: string;
+  };
+  sms: {
+    provider: "console" | "twilio";
+    from: string;
+    twilio?: {
+      accountSid: string;
+      authToken: string;
+      messagingServiceSid?: string;
+    };
+  };
+  appUserSync: {
+    enabled: boolean;
+  };
+}
+
+const ensureSearchPath = (rawUrl: string, schema: string): string => {
+  const u = new URL(rawUrl);
+  const existing = u.searchParams.get("options");
+  const directive = `-c search_path=${schema}`;
+  if (existing) {
+    if (existing.includes("search_path=")) return u.toString();
+    u.searchParams.set("options", `${existing} ${directive}`);
+  } else {
+    u.searchParams.set("options", directive);
+  }
+  return u.toString();
+};
+
+export const loadConfig = (): AuthConfig => {
+  const env = envSchema.parse(process.env);
+
+  const features = {
+    google: featureFlag(env.FEATURE_GOOGLE, true),
+    emailOtp: featureFlag(env.FEATURE_EMAIL_OTP, true),
+    smsOtp: featureFlag(env.FEATURE_SMS_OTP, true),
+  };
+
+  if (features.google && (!env.GOOGLE_CLIENT_ID || !env.GOOGLE_CLIENT_SECRET)) {
+    throw new Error(
+      "FEATURE_GOOGLE is on but GOOGLE_CLIENT_ID / GOOGLE_CLIENT_SECRET are not set",
+    );
+  }
+  if (
+    (features.emailOtp || features.smsOtp) &&
+    env.EMAIL_PROVIDER === "resend" &&
+    !env.RESEND_API_KEY
+  ) {
+    throw new Error("EMAIL_PROVIDER=resend requires RESEND_API_KEY");
+  }
+  if (features.smsOtp && env.SMS_PROVIDER === "twilio") {
+    if (!env.TWILIO_ACCOUNT_SID || !env.TWILIO_AUTH_TOKEN) {
+      throw new Error(
+        "SMS_PROVIDER=twilio requires TWILIO_ACCOUNT_SID and TWILIO_AUTH_TOKEN",
+      );
+    }
+  }
+
+  const trustedOrigins = (env.TRUSTED_ORIGINS ?? env.APP_BASE_URL)
+    .split(",")
+    .map((s) => s.trim())
+    .filter(Boolean);
+
+  const databaseUrl = ensureSearchPath(env.DATABASE_URL, env.AUTH_DB_SCHEMA);
+
+  return {
+    baseURL: env.APP_BASE_URL,
+    basePath: env.AUTH_BASE_PATH,
+    internalPort: env.AUTH_INTERNAL_PORT,
+    secret: env.BETTER_AUTH_SECRET,
+    trustedOrigins,
+    database: {
+      url: databaseUrl,
+      schema: env.AUTH_DB_SCHEMA,
+    },
+    features,
+    google:
+      features.google && env.GOOGLE_CLIENT_ID && env.GOOGLE_CLIENT_SECRET
+        ? {
+            clientId: env.GOOGLE_CLIENT_ID,
+            clientSecret: env.GOOGLE_CLIENT_SECRET,
+          }
+        : undefined,
+    email: {
+      provider: env.EMAIL_PROVIDER,
+      from: env.EMAIL_FROM ?? "no-reply@localhost",
+      resendApiKey: env.RESEND_API_KEY,
+    },
+    sms: {
+      provider: env.SMS_PROVIDER,
+      from: env.SMS_FROM ?? "",
+      twilio:
+        env.SMS_PROVIDER === "twilio" &&
+        env.TWILIO_ACCOUNT_SID &&
+        env.TWILIO_AUTH_TOKEN
+          ? {
+              accountSid: env.TWILIO_ACCOUNT_SID,
+              authToken: env.TWILIO_AUTH_TOKEN,
+              messagingServiceSid: env.TWILIO_MESSAGING_SERVICE_SID,
+            }
+          : undefined,
+    },
+    appUserSync: {
+      enabled: featureFlag(env.APP_USER_SYNC_ENABLED, true),
+    },
+  };
+};

--- a/auth-service/src/config.ts
+++ b/auth-service/src/config.ts
@@ -1,42 +1,35 @@
 import { z } from "zod";
+import { buildDatabaseUrl, loadSecrets } from "./secrets.js";
 
-const featureFlag = (raw: string | undefined, fallback: boolean): boolean => {
+// Non-secret configuration. All values default to something sensible for
+// local dev so a fresh checkout with a populated `secrets.json` "just works".
+// Production overrides go in fly.toml's [env] block.
+const flag = (raw: string | undefined, fallback: boolean): boolean => {
   if (raw === undefined) return fallback;
   return ["1", "true", "yes", "on"].includes(raw.toLowerCase());
 };
 
 const envSchema = z.object({
-  APP_BASE_URL: z.string().url(),
+  APP_BASE_URL: z.string().url().default("http://localhost:3009"),
   AUTH_BASE_PATH: z.string().default("/api/auth"),
   AUTH_INTERNAL_PORT: z.coerce.number().int().default(3001),
   TRUSTED_ORIGINS: z.string().optional(),
 
-  BETTER_AUTH_SECRET: z.string().min(32, "BETTER_AUTH_SECRET must be at least 32 chars"),
-
-  DATABASE_URL: z.string().url(),
   AUTH_DB_SCHEMA: z.string().default("auth"),
 
   FEATURE_GOOGLE: z.string().optional(),
   FEATURE_EMAIL_OTP: z.string().optional(),
   FEATURE_SMS_OTP: z.string().optional(),
 
-  GOOGLE_CLIENT_ID: z.string().optional(),
-  GOOGLE_CLIENT_SECRET: z.string().optional(),
-
   EMAIL_PROVIDER: z.enum(["console", "resend"]).default("console"),
-  EMAIL_FROM: z.string().optional(),
-  RESEND_API_KEY: z.string().optional(),
+  EMAIL_FROM: z.string().default("no-reply@localhost"),
 
   SMS_PROVIDER: z.enum(["console", "twilio"]).default("console"),
-  SMS_FROM: z.string().optional(),
-  TWILIO_ACCOUNT_SID: z.string().optional(),
-  TWILIO_AUTH_TOKEN: z.string().optional(),
+  SMS_FROM: z.string().default(""),
   TWILIO_MESSAGING_SERVICE_SID: z.string().optional(),
 
   APP_USER_SYNC_ENABLED: z.string().optional(),
 });
-
-export type AuthEnv = z.infer<typeof envSchema>;
 
 export interface AuthConfig {
   baseURL: string;
@@ -76,94 +69,82 @@ export interface AuthConfig {
   };
 }
 
-const ensureSearchPath = (rawUrl: string, schema: string): string => {
-  const u = new URL(rawUrl);
-  const existing = u.searchParams.get("options");
-  const directive = `-c search_path=${schema}`;
-  if (existing) {
-    if (existing.includes("search_path=")) return u.toString();
-    u.searchParams.set("options", `${existing} ${directive}`);
-  } else {
-    u.searchParams.set("options", directive);
-  }
-  return u.toString();
-};
-
 export const loadConfig = (): AuthConfig => {
   const env = envSchema.parse(process.env);
+  const secrets = loadSecrets();
 
+  // Default Google off locally because most dev machines don't have OAuth
+  // credentials configured. Production fly.toml flips it on explicitly.
   const features = {
-    google: featureFlag(env.FEATURE_GOOGLE, true),
-    emailOtp: featureFlag(env.FEATURE_EMAIL_OTP, true),
-    smsOtp: featureFlag(env.FEATURE_SMS_OTP, true),
+    google: flag(env.FEATURE_GOOGLE, false),
+    emailOtp: flag(env.FEATURE_EMAIL_OTP, true),
+    smsOtp: flag(env.FEATURE_SMS_OTP, true),
   };
 
-  if (features.google && (!env.GOOGLE_CLIENT_ID || !env.GOOGLE_CLIENT_SECRET)) {
+  const google =
+    features.google && secrets.auth.googleClientId && secrets.auth.googleClientSecret
+      ? {
+          clientId: secrets.auth.googleClientId,
+          clientSecret: secrets.auth.googleClientSecret,
+        }
+      : undefined;
+  if (features.google && !google) {
     throw new Error(
-      "FEATURE_GOOGLE is on but GOOGLE_CLIENT_ID / GOOGLE_CLIENT_SECRET are not set",
+      "FEATURE_GOOGLE=true but secrets.auth.googleClientId / googleClientSecret are not set",
     );
   }
-  if (
-    (features.emailOtp || features.smsOtp) &&
-    env.EMAIL_PROVIDER === "resend" &&
-    !env.RESEND_API_KEY
-  ) {
-    throw new Error("EMAIL_PROVIDER=resend requires RESEND_API_KEY");
+
+  if (env.EMAIL_PROVIDER === "resend" && !secrets.auth.resendApiKey) {
+    throw new Error("EMAIL_PROVIDER=resend requires secrets.auth.resendApiKey");
   }
-  if (features.smsOtp && env.SMS_PROVIDER === "twilio") {
-    if (!env.TWILIO_ACCOUNT_SID || !env.TWILIO_AUTH_TOKEN) {
+  if (env.SMS_PROVIDER === "twilio") {
+    if (!secrets.auth.twilioAccountSid || !secrets.auth.twilioAuthToken) {
       throw new Error(
-        "SMS_PROVIDER=twilio requires TWILIO_ACCOUNT_SID and TWILIO_AUTH_TOKEN",
+        "SMS_PROVIDER=twilio requires secrets.auth.twilioAccountSid and secrets.auth.twilioAuthToken",
       );
     }
   }
 
-  const trustedOrigins = (env.TRUSTED_ORIGINS ?? env.APP_BASE_URL)
+  const trustedOrigins = (
+    env.TRUSTED_ORIGINS ?? `${env.APP_BASE_URL},http://localhost:3000`
+  )
     .split(",")
     .map((s) => s.trim())
     .filter(Boolean);
-
-  const databaseUrl = ensureSearchPath(env.DATABASE_URL, env.AUTH_DB_SCHEMA);
 
   return {
     baseURL: env.APP_BASE_URL,
     basePath: env.AUTH_BASE_PATH,
     internalPort: env.AUTH_INTERNAL_PORT,
-    secret: env.BETTER_AUTH_SECRET,
+    secret: secrets.auth.betterAuthSecret,
     trustedOrigins,
     database: {
-      url: databaseUrl,
+      url: buildDatabaseUrl(secrets.db, env.AUTH_DB_SCHEMA),
       schema: env.AUTH_DB_SCHEMA,
     },
     features,
-    google:
-      features.google && env.GOOGLE_CLIENT_ID && env.GOOGLE_CLIENT_SECRET
-        ? {
-            clientId: env.GOOGLE_CLIENT_ID,
-            clientSecret: env.GOOGLE_CLIENT_SECRET,
-          }
-        : undefined,
+    google,
     email: {
       provider: env.EMAIL_PROVIDER,
-      from: env.EMAIL_FROM ?? "no-reply@localhost",
-      resendApiKey: env.RESEND_API_KEY,
+      from: env.EMAIL_FROM,
+      resendApiKey: secrets.auth.resendApiKey,
     },
     sms: {
       provider: env.SMS_PROVIDER,
-      from: env.SMS_FROM ?? "",
+      from: env.SMS_FROM,
       twilio:
         env.SMS_PROVIDER === "twilio" &&
-        env.TWILIO_ACCOUNT_SID &&
-        env.TWILIO_AUTH_TOKEN
+        secrets.auth.twilioAccountSid &&
+        secrets.auth.twilioAuthToken
           ? {
-              accountSid: env.TWILIO_ACCOUNT_SID,
-              authToken: env.TWILIO_AUTH_TOKEN,
+              accountSid: secrets.auth.twilioAccountSid,
+              authToken: secrets.auth.twilioAuthToken,
               messagingServiceSid: env.TWILIO_MESSAGING_SERVICE_SID,
             }
           : undefined,
     },
     appUserSync: {
-      enabled: featureFlag(env.APP_USER_SYNC_ENABLED, true),
+      enabled: flag(env.APP_USER_SYNC_ENABLED, false),
     },
   };
 };

--- a/auth-service/src/plugins.ts
+++ b/auth-service/src/plugins.ts
@@ -1,10 +1,8 @@
 import { emailOTP, jwt, phoneNumber } from "better-auth/plugins";
 import type { AuthConfig } from "./config.js";
-import { buildEmailSender, buildSmsSender } from "./providers/index.js";
+import { buildEmailSender, buildSmsService } from "./providers/index.js";
 
 // Better Auth plugins are heterogeneous; betterAuth() accepts the union.
-// Using a permissive array type keeps the TS inference cheap and stable
-// across plugin version bumps.
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type AuthPlugin = any;
 
@@ -33,15 +31,27 @@ export const buildPlugins = (config: AuthConfig): AuthPlugin[] => {
   }
 
   if (config.features.smsOtp) {
-    const sms = buildSmsSender(config);
+    const sms = buildSmsService(config);
+    // Twilio Verify mode: Twilio generates and validates the OTP. We
+    // delegate verification to Twilio via Better Auth's `verifyOTP` hook
+    // so we never store SMS codes ourselves.
+    const twilioVerifyMode = sms.verify !== undefined;
     plugins.push(
       phoneNumber({
         otpLength: 6,
         expiresIn: 300,
         allowedAttempts: 3,
         async sendOTP({ phoneNumber: to, code }) {
-          await sms.send({ to, body: `Your code is: ${code}` });
+          await sms.send({ to, code });
         },
+        ...(twilioVerifyMode
+          ? {
+              verifyOTP: async ({ phoneNumber: to, code }) => {
+                if (!sms.verify) return false;
+                return sms.verify({ to, code });
+              },
+            }
+          : {}),
         signUpOnVerification: {
           getTempEmail: (phone) => `${phone.replace(/[^0-9]/g, "")}@phone.local`,
           getTempName: (phone) => phone,

--- a/auth-service/src/plugins.ts
+++ b/auth-service/src/plugins.ts
@@ -1,0 +1,56 @@
+import { emailOTP, jwt, phoneNumber } from "better-auth/plugins";
+import type { AuthConfig } from "./config.js";
+import { buildEmailSender, buildSmsSender } from "./providers/index.js";
+
+// Better Auth plugins are heterogeneous; betterAuth() accepts the union.
+// Using a permissive array type keeps the TS inference cheap and stable
+// across plugin version bumps.
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type AuthPlugin = any;
+
+export const buildPlugins = (config: AuthConfig): AuthPlugin[] => {
+  const plugins: AuthPlugin[] = [];
+
+  if (config.features.emailOtp) {
+    const email = buildEmailSender(config);
+    plugins.push(
+      emailOTP({
+        otpLength: 6,
+        expiresIn: 300,
+        allowedAttempts: 3,
+        async sendVerificationOTP({ email: to, otp, type }) {
+          const subject =
+            type === "sign-in"
+              ? "Your sign-in code"
+              : type === "email-verification"
+                ? "Verify your email"
+                : "Your password reset code";
+          const body = `Your code is: ${otp}\n\nIt expires in 5 minutes.`;
+          await email.send({ to, subject, body });
+        },
+      }),
+    );
+  }
+
+  if (config.features.smsOtp) {
+    const sms = buildSmsSender(config);
+    plugins.push(
+      phoneNumber({
+        otpLength: 6,
+        expiresIn: 300,
+        allowedAttempts: 3,
+        async sendOTP({ phoneNumber: to, code }) {
+          await sms.send({ to, body: `Your code is: ${code}` });
+        },
+        signUpOnVerification: {
+          getTempEmail: (phone) => `${phone.replace(/[^0-9]/g, "")}@phone.local`,
+          getTempName: (phone) => phone,
+        },
+      }),
+    );
+  }
+
+  plugins.push(jwt());
+
+  return plugins;
+};

--- a/auth-service/src/providers/email-console.ts
+++ b/auth-service/src/providers/email-console.ts
@@ -1,0 +1,9 @@
+import type { EmailSender } from "./types.js";
+
+export const consoleEmailSender = (): EmailSender => ({
+  async send({ to, subject, body }) {
+    console.log(
+      `[email-console] to=${to} subject=${JSON.stringify(subject)} body=${JSON.stringify(body)}`,
+    );
+  },
+});

--- a/auth-service/src/providers/email-resend.ts
+++ b/auth-service/src/providers/email-resend.ts
@@ -1,0 +1,19 @@
+import { Resend } from "resend";
+import type { EmailSender } from "./types.js";
+
+export const resendEmailSender = (apiKey: string, from: string): EmailSender => {
+  const client = new Resend(apiKey);
+  return {
+    async send({ to, subject, body }) {
+      const { error } = await client.emails.send({
+        from,
+        to,
+        subject,
+        text: body,
+      });
+      if (error) {
+        throw new Error(`resend send failed: ${error.message ?? JSON.stringify(error)}`);
+      }
+    },
+  };
+};

--- a/auth-service/src/providers/index.ts
+++ b/auth-service/src/providers/index.ts
@@ -1,0 +1,37 @@
+import type { AuthConfig } from "../config.js";
+import { consoleEmailSender } from "./email-console.js";
+import { resendEmailSender } from "./email-resend.js";
+import { consoleSmsSender } from "./sms-console.js";
+import { twilioSmsSender } from "./sms-twilio.js";
+import type { EmailSender, SmsSender } from "./types.js";
+
+export const buildEmailSender = (config: AuthConfig): EmailSender => {
+  switch (config.email.provider) {
+    case "resend":
+      if (!config.email.resendApiKey) {
+        throw new Error("resend provider selected but no api key configured");
+      }
+      return resendEmailSender(config.email.resendApiKey, config.email.from);
+    case "console":
+    default:
+      return consoleEmailSender();
+  }
+};
+
+export const buildSmsSender = (config: AuthConfig): SmsSender => {
+  switch (config.sms.provider) {
+    case "twilio":
+      if (!config.sms.twilio) {
+        throw new Error("twilio provider selected but credentials missing");
+      }
+      return twilioSmsSender({
+        accountSid: config.sms.twilio.accountSid,
+        authToken: config.sms.twilio.authToken,
+        from: config.sms.from,
+        messagingServiceSid: config.sms.twilio.messagingServiceSid,
+      });
+    case "console":
+    default:
+      return consoleSmsSender();
+  }
+};

--- a/auth-service/src/providers/index.ts
+++ b/auth-service/src/providers/index.ts
@@ -1,9 +1,9 @@
 import type { AuthConfig } from "../config.js";
 import { consoleEmailSender } from "./email-console.js";
 import { resendEmailSender } from "./email-resend.js";
-import { consoleSmsSender } from "./sms-console.js";
-import { twilioSmsSender } from "./sms-twilio.js";
-import type { EmailSender, SmsSender } from "./types.js";
+import { consoleSmsService } from "./sms-console.js";
+import { twilioSmsService } from "./sms-twilio.js";
+import type { EmailSender, SmsService } from "./types.js";
 
 export const buildEmailSender = (config: AuthConfig): EmailSender => {
   switch (config.email.provider) {
@@ -18,20 +18,21 @@ export const buildEmailSender = (config: AuthConfig): EmailSender => {
   }
 };
 
-export const buildSmsSender = (config: AuthConfig): SmsSender => {
+export const buildSmsService = (config: AuthConfig): SmsService => {
   switch (config.sms.provider) {
     case "twilio":
       if (!config.sms.twilio) {
         throw new Error("twilio provider selected but credentials missing");
       }
-      return twilioSmsSender({
+      return twilioSmsService({
         accountSid: config.sms.twilio.accountSid,
         authToken: config.sms.twilio.authToken,
-        from: config.sms.from,
+        from: config.sms.from || undefined,
         messagingServiceSid: config.sms.twilio.messagingServiceSid,
+        verifyServiceSid: config.sms.twilio.verifyServiceSid,
       });
     case "console":
     default:
-      return consoleSmsSender();
+      return consoleSmsService();
   }
 };

--- a/auth-service/src/providers/sms-console.ts
+++ b/auth-service/src/providers/sms-console.ts
@@ -1,7 +1,10 @@
-import type { SmsSender } from "./types.js";
+import type { SmsService } from "./types.js";
 
-export const consoleSmsSender = (): SmsSender => ({
-  async send({ to, body }) {
-    console.log(`[sms-console] to=${to} body=${JSON.stringify(body)}`);
+// Dev-only SMS service: prints OTPs to stdout instead of sending real SMS.
+// Better Auth still generates and verifies the codes itself, so no `verify`
+// hook is needed.
+export const consoleSmsService = (): SmsService => ({
+  async send({ to, code }) {
+    console.log(`[sms-console] to=${to} code=${code}`);
   },
 });

--- a/auth-service/src/providers/sms-console.ts
+++ b/auth-service/src/providers/sms-console.ts
@@ -1,0 +1,7 @@
+import type { SmsSender } from "./types.js";
+
+export const consoleSmsSender = (): SmsSender => ({
+  async send({ to, body }) {
+    console.log(`[sms-console] to=${to} body=${JSON.stringify(body)}`);
+  },
+});

--- a/auth-service/src/providers/sms-twilio.ts
+++ b/auth-service/src/providers/sms-twilio.ts
@@ -23,8 +23,24 @@ export const twilioSmsService = (opts: TwilioSmsOptions): SmsService => {
         await service.verifications.create({ to, channel: "sms" });
       },
       async verify({ to, code }) {
-        const result = await service.verificationChecks.create({ to, code });
-        return result.status === "approved";
+        // Twilio throws on transport/auth/rate errors. Treat any error
+        // here as "could not verify" so Better Auth returns a clean 4xx
+        // INVALID_OTP instead of leaking a 5xx + stack to the client.
+        // We still log so ops can distinguish "wrong code" from "Twilio
+        // is broken / rate-limited" in production logs.
+        try {
+          const result = await service.verificationChecks.create({ to, code });
+          return result.status === "approved";
+        } catch (err) {
+          const status =
+            (err as { status?: number; code?: number }).status ??
+            (err as { code?: number }).code;
+          console.error(
+            `[sms-twilio] verificationChecks.create failed (status=${status}):`,
+            err,
+          );
+          return false;
+        }
       },
     };
   }

--- a/auth-service/src/providers/sms-twilio.ts
+++ b/auth-service/src/providers/sms-twilio.ts
@@ -1,0 +1,27 @@
+import twilio from "twilio";
+import type { SmsSender } from "./types.js";
+
+export interface TwilioSmsOptions {
+  accountSid: string;
+  authToken: string;
+  from: string;
+  messagingServiceSid?: string;
+}
+
+export const twilioSmsSender = (opts: TwilioSmsOptions): SmsSender => {
+  const client = twilio(opts.accountSid, opts.authToken);
+  return {
+    async send({ to, body }) {
+      const params: Parameters<typeof client.messages.create>[0] = {
+        to,
+        body,
+      };
+      if (opts.messagingServiceSid) {
+        params.messagingServiceSid = opts.messagingServiceSid;
+      } else {
+        params.from = opts.from;
+      }
+      await client.messages.create(params);
+    },
+  };
+};

--- a/auth-service/src/providers/sms-twilio.ts
+++ b/auth-service/src/providers/sms-twilio.ts
@@ -1,25 +1,47 @@
 import twilio from "twilio";
-import type { SmsSender } from "./types.js";
+import type { SmsService } from "./types.js";
 
 export interface TwilioSmsOptions {
   accountSid: string;
   authToken: string;
-  from: string;
+  from?: string;
   messagingServiceSid?: string;
+  // When set, run SMS OTP through Twilio Verify instead of raw messaging.
+  // Twilio generates the code, sends it, validates it, and protects against
+  // SIM-swap / abuse. Recommended.
+  verifyServiceSid?: string;
 }
 
-export const twilioSmsSender = (opts: TwilioSmsOptions): SmsSender => {
+export const twilioSmsService = (opts: TwilioSmsOptions): SmsService => {
   const client = twilio(opts.accountSid, opts.authToken);
+
+  if (opts.verifyServiceSid) {
+    const service = client.verify.v2.services(opts.verifyServiceSid);
+    return {
+      async send({ to }) {
+        // Twilio Verify generates and sends its own code.
+        await service.verifications.create({ to, channel: "sms" });
+      },
+      async verify({ to, code }) {
+        const result = await service.verificationChecks.create({ to, code });
+        return result.status === "approved";
+      },
+    };
+  }
+
+  // Fallback: raw messaging — caller (Better Auth) generates the code.
   return {
-    async send({ to, body }) {
+    async send({ to, code }) {
       const params: Parameters<typeof client.messages.create>[0] = {
         to,
-        body,
+        body: `Your code is: ${code}`,
       };
       if (opts.messagingServiceSid) {
         params.messagingServiceSid = opts.messagingServiceSid;
-      } else {
+      } else if (opts.from) {
         params.from = opts.from;
+      } else {
+        throw new Error("twilio raw messaging requires `from` or `messagingServiceSid`");
       }
       await client.messages.create(params);
     },

--- a/auth-service/src/providers/types.ts
+++ b/auth-service/src/providers/types.ts
@@ -8,11 +8,16 @@ export interface EmailSender {
   send(message: EmailMessage): Promise<void>;
 }
 
-export interface SmsMessage {
-  to: string;
-  body: string;
-}
+// Two-method SMS interface so the same shape works for both raw messaging
+// (we generate the OTP, Twilio just sends it) and Twilio Verify (Twilio
+// generates, sends, and verifies — we never see the code).
+export interface SmsService {
+  // For raw-messaging providers, `code` is the OTP to send. For Twilio
+  // Verify, `code` is ignored — Twilio generates its own.
+  send(args: { to: string; code: string }): Promise<void>;
 
-export interface SmsSender {
-  send(message: SmsMessage): Promise<void>;
+  // Returns true if the code is valid. For raw-messaging providers, this
+  // is null (Better Auth verifies internally). For Twilio Verify, this
+  // delegates the check to Twilio's API.
+  verify?: (args: { to: string; code: string }) => Promise<boolean>;
 }

--- a/auth-service/src/providers/types.ts
+++ b/auth-service/src/providers/types.ts
@@ -1,0 +1,18 @@
+export interface EmailMessage {
+  to: string;
+  subject: string;
+  body: string;
+}
+
+export interface EmailSender {
+  send(message: EmailMessage): Promise<void>;
+}
+
+export interface SmsMessage {
+  to: string;
+  body: string;
+}
+
+export interface SmsSender {
+  send(message: SmsMessage): Promise<void>;
+}

--- a/auth-service/src/secrets.ts
+++ b/auth-service/src/secrets.ts
@@ -39,16 +39,31 @@ interface SecretsFile {
   [k: string]: unknown;
 }
 
-const SECRETS_FILENAMES = ["secrets.json", "secrets-test.json"];
+// Mirrors the Go-side `secretsFileCandidates` selector: ALPHA_ENV picks
+// the file. Default order (no env set) prefers prod `secrets.json`, with
+// `secrets-test.json` as a fallback for fresh checkouts.
+const candidatesForEnv = (env: string | undefined): string[] => {
+  switch (env) {
+    case "dev":
+      return ["secrets-dev.json", "secrets.json"];
+    case "test":
+      return ["secrets-test.json"];
+    case "prod":
+      return ["secrets.json"];
+    default:
+      return ["secrets.json", "secrets-test.json"];
+  }
+};
 
 // Walks up from `start` looking for any of the secrets filenames. Same
 // strategy as Go's `secretsFileCandidates`, but rooted from the auth-service
 // folder so it works whether you `cd auth-service && npm run dev` or run
 // the compiled binary out of `/app/auth-service` in the Fly image.
 const findSecretsFile = (start: string): string | null => {
+  const filenames = candidatesForEnv(process.env.ALPHA_ENV);
   let dir = resolve(start);
   for (let i = 0; i < 6; i++) {
-    for (const name of SECRETS_FILENAMES) {
+    for (const name of filenames) {
       const candidate = join(dir, name);
       if (existsSync(candidate)) return candidate;
     }

--- a/auth-service/src/secrets.ts
+++ b/auth-service/src/secrets.ts
@@ -20,6 +20,10 @@ export interface AuthSecrets {
   resendApiKey?: string;
   twilioAccountSid?: string;
   twilioAuthToken?: string;
+  // The Twilio Verify Service SID. Required when running SMS OTP through
+  // Twilio Verify (the recommended mode — Twilio handles code generation,
+  // delivery, retry, and fraud protection; we never see or store the code).
+  twilioVerifyServiceSid?: string;
 }
 
 export interface ResolvedSecrets {
@@ -83,6 +87,7 @@ const loadFromEnv = (): ResolvedSecrets => {
       resendApiKey: process.env.resendApiKey,
       twilioAccountSid: process.env.twilioAccountSid,
       twilioAuthToken: process.env.twilioAuthToken,
+      twilioVerifyServiceSid: process.env.twilioVerifyServiceSid,
     },
   };
 };
@@ -137,6 +142,10 @@ const loadFromFile = (path: string): ResolvedSecrets => {
       twilioAuthToken:
         typeof auth.twilioAuthToken === "string"
           ? auth.twilioAuthToken
+          : undefined,
+      twilioVerifyServiceSid:
+        typeof auth.twilioVerifyServiceSid === "string"
+          ? auth.twilioVerifyServiceSid
           : undefined,
     },
   };

--- a/auth-service/src/secrets.ts
+++ b/auth-service/src/secrets.ts
@@ -74,6 +74,22 @@ const findSecretsFile = (start: string): string | null => {
   return null;
 };
 
+// Minimum entropy for the Better Auth signing secret. 32 chars matches what
+// `openssl rand -hex 16` produces (16 bytes); a hex-encoded 32-byte secret
+// is 64 chars. We pick 32 as a conservative floor.
+const MIN_BETTER_AUTH_SECRET_LEN = 32;
+
+const validateBetterAuthSecret = (s: string): string => {
+  if (s.length < MIN_BETTER_AUTH_SECRET_LEN) {
+    throw new Error(
+      `betterAuthSecret is too short (${s.length} chars). ` +
+        `Use at least ${MIN_BETTER_AUTH_SECRET_LEN} characters; ` +
+        `generate with \`openssl rand -hex 32\`.`,
+    );
+  }
+  return s;
+};
+
 const loadFromEnv = (): ResolvedSecrets => {
   const need = (name: string): string => {
     const v = process.env[name];
@@ -96,7 +112,7 @@ const loadFromEnv = (): ResolvedSecrets => {
         : true,
     },
     auth: {
-      betterAuthSecret: need("betterAuthSecret"),
+      betterAuthSecret: validateBetterAuthSecret(need("betterAuthSecret")),
       googleClientId: process.env.googleClientId,
       googleClientSecret: process.env.googleClientSecret,
       resendApiKey: process.env.resendApiKey,
@@ -141,7 +157,9 @@ const loadFromFile = (path: string): ResolvedSecrets => {
       enableSsl: typeof db.enableSsl === "boolean" ? db.enableSsl : true,
     },
     auth: {
-      betterAuthSecret: requireString(auth, "betterAuthSecret", "auth"),
+      betterAuthSecret: validateBetterAuthSecret(
+        requireString(auth, "betterAuthSecret", "auth"),
+      ),
       googleClientId:
         typeof auth.googleClientId === "string" ? auth.googleClientId : undefined,
       googleClientSecret:
@@ -183,6 +201,13 @@ export const loadSecrets = (cwd = process.cwd()): ResolvedSecrets => {
 // Builds a Postgres connection string with `?options=-c search_path=<schema>`
 // applied so Better Auth lands tables in the correct schema.
 export const buildDatabaseUrl = (db: DbSecrets, schema: string): string => {
+  // Defense in depth: even though zod typechecks `schema` as a string, the
+  // value is interpolated directly into the connection string's `options`
+  // parameter, which Postgres parses as a server-side SET command. A weird
+  // value here could surprise the search_path or break the connection.
+  if (!/^[a-zA-Z_][a-zA-Z0-9_]*$/.test(schema)) {
+    throw new Error(`unsafe AUTH_DB_SCHEMA: ${schema}`);
+  }
   const u = new URL("postgres://placeholder/placeholder");
   u.username = encodeURIComponent(db.user);
   u.password = encodeURIComponent(db.password);

--- a/auth-service/src/secrets.ts
+++ b/auth-service/src/secrets.ts
@@ -1,0 +1,175 @@
+import { existsSync, readFileSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+
+// Mirrors the Go-side `Secrets` struct in internal/util/util.go. Only the
+// fields the auth-service actually consumes are typed here; the rest are
+// allowed to exist in the JSON without complaint.
+export interface DbSecrets {
+  host: string;
+  port: string;
+  user: string;
+  password: string;
+  database: string;
+  enableSsl?: boolean;
+}
+
+export interface AuthSecrets {
+  betterAuthSecret: string;
+  googleClientId?: string;
+  googleClientSecret?: string;
+  resendApiKey?: string;
+  twilioAccountSid?: string;
+  twilioAuthToken?: string;
+}
+
+export interface ResolvedSecrets {
+  db: DbSecrets;
+  auth: AuthSecrets;
+}
+
+interface SecretsFile {
+  db?: Partial<DbSecrets>;
+  auth?: Partial<AuthSecrets>;
+  // Other top-level keys (`gpt`, `jwt`, `alpaca`, etc.) are tolerated but
+  // ignored here — they belong to the Go side.
+  [k: string]: unknown;
+}
+
+const SECRETS_FILENAMES = ["secrets.json", "secrets-test.json"];
+
+// Walks up from `start` looking for any of the secrets filenames. Same
+// strategy as Go's `secretsFileCandidates`, but rooted from the auth-service
+// folder so it works whether you `cd auth-service && npm run dev` or run
+// the compiled binary out of `/app/auth-service` in the Fly image.
+const findSecretsFile = (start: string): string | null => {
+  let dir = resolve(start);
+  for (let i = 0; i < 6; i++) {
+    for (const name of SECRETS_FILENAMES) {
+      const candidate = join(dir, name);
+      if (existsSync(candidate)) return candidate;
+    }
+    const parent = dirname(dir);
+    if (parent === dir) break;
+    dir = parent;
+  }
+  return null;
+};
+
+const loadFromEnv = (): ResolvedSecrets => {
+  const need = (name: string): string => {
+    const v = process.env[name];
+    if (!v) {
+      throw new Error(
+        `FB_SECRETS_FROM_ENV=1 but env var "${name}" is not set`,
+      );
+    }
+    return v;
+  };
+  return {
+    db: {
+      host: need("host"),
+      port: need("port"),
+      user: need("user"),
+      password: need("password"),
+      database: need("database"),
+      enableSsl: process.env.enableSsl
+        ? process.env.enableSsl !== "false"
+        : true,
+    },
+    auth: {
+      betterAuthSecret: need("betterAuthSecret"),
+      googleClientId: process.env.googleClientId,
+      googleClientSecret: process.env.googleClientSecret,
+      resendApiKey: process.env.resendApiKey,
+      twilioAccountSid: process.env.twilioAccountSid,
+      twilioAuthToken: process.env.twilioAuthToken,
+    },
+  };
+};
+
+const loadFromFile = (path: string): ResolvedSecrets => {
+  const raw = readFileSync(path, "utf8");
+  const parsed = JSON.parse(raw) as SecretsFile;
+  if (!parsed.db) {
+    throw new Error(`secrets file ${path} is missing the "db" section`);
+  }
+  if (!parsed.auth) {
+    throw new Error(
+      `secrets file ${path} is missing the "auth" section. Add at minimum: { "betterAuthSecret": "<32 byte hex>" }`,
+    );
+  }
+  const requireString = (
+    obj: Record<string, unknown>,
+    key: string,
+    section: string,
+  ): string => {
+    const v = obj[key];
+    if (typeof v !== "string" || v.length === 0) {
+      throw new Error(`secrets file ${path}: missing ${section}.${key}`);
+    }
+    return v;
+  };
+  const db = parsed.db as Record<string, unknown>;
+  const auth = parsed.auth as Record<string, unknown>;
+  return {
+    db: {
+      host: requireString(db, "host", "db"),
+      port: requireString(db, "port", "db"),
+      user: requireString(db, "user", "db"),
+      password: requireString(db, "password", "db"),
+      database: requireString(db, "database", "db"),
+      enableSsl: typeof db.enableSsl === "boolean" ? db.enableSsl : true,
+    },
+    auth: {
+      betterAuthSecret: requireString(auth, "betterAuthSecret", "auth"),
+      googleClientId:
+        typeof auth.googleClientId === "string" ? auth.googleClientId : undefined,
+      googleClientSecret:
+        typeof auth.googleClientSecret === "string"
+          ? auth.googleClientSecret
+          : undefined,
+      resendApiKey:
+        typeof auth.resendApiKey === "string" ? auth.resendApiKey : undefined,
+      twilioAccountSid:
+        typeof auth.twilioAccountSid === "string"
+          ? auth.twilioAccountSid
+          : undefined,
+      twilioAuthToken:
+        typeof auth.twilioAuthToken === "string"
+          ? auth.twilioAuthToken
+          : undefined,
+    },
+  };
+};
+
+export const loadSecrets = (cwd = process.cwd()): ResolvedSecrets => {
+  if (process.env.FB_SECRETS_FROM_ENV === "1") {
+    return loadFromEnv();
+  }
+  const path = findSecretsFile(cwd);
+  if (!path) {
+    throw new Error(
+      `could not find secrets.json (searched up from ${cwd}). ` +
+        `Either create one (see secrets-test.json for the shape) or set FB_SECRETS_FROM_ENV=1.`,
+    );
+  }
+  return loadFromFile(path);
+};
+
+// Builds a Postgres connection string with `?options=-c search_path=<schema>`
+// applied so Better Auth lands tables in the correct schema.
+export const buildDatabaseUrl = (db: DbSecrets, schema: string): string => {
+  const u = new URL("postgres://placeholder/placeholder");
+  u.username = encodeURIComponent(db.user);
+  u.password = encodeURIComponent(db.password);
+  u.hostname = db.host;
+  u.port = db.port;
+  u.pathname = `/${db.database}`;
+  if (db.enableSsl !== false) {
+    u.searchParams.set("sslmode", "require");
+  } else {
+    u.searchParams.set("sslmode", "disable");
+  }
+  u.searchParams.set("options", `-c search_path=${schema}`);
+  return u.toString();
+};

--- a/auth-service/src/server.ts
+++ b/auth-service/src/server.ts
@@ -1,0 +1,33 @@
+import { serve } from "@hono/node-server";
+import { Hono } from "hono";
+import { auth, config, pool } from "../auth.js";
+
+const app = new Hono();
+
+app.get("/api/auth/ok", (c) => c.json({ ok: true }));
+
+app.on(["GET", "POST"], "/api/auth/*", (c) => auth.handler(c.req.raw));
+
+app.notFound((c) =>
+  c.json({ error: "not found", path: c.req.path }, 404),
+);
+
+const port = config.internalPort;
+
+const server = serve({
+  fetch: app.fetch,
+  hostname: "127.0.0.1",
+  port,
+});
+
+console.log(`[auth-service] listening on http://127.0.0.1:${port}${config.basePath}`);
+
+const shutdown = async (signal: string) => {
+  console.log(`[auth-service] received ${signal}, shutting down`);
+  server.close();
+  await pool.end().catch(() => undefined);
+  process.exit(0);
+};
+
+process.on("SIGTERM", () => void shutdown("SIGTERM"));
+process.on("SIGINT", () => void shutdown("SIGINT"));

--- a/auth-service/src/sync/app-user-profile.ts
+++ b/auth-service/src/sync/app-user-profile.ts
@@ -1,0 +1,55 @@
+import type { Pool } from "pg";
+
+interface SyncDeps {
+  pool: Pool;
+  enabled: boolean;
+}
+
+interface BetterAuthUserLike {
+  id: string;
+  email?: string | null;
+  name?: string | null;
+  phoneNumber?: string | null;
+}
+
+export const buildDatabaseHooks = ({ pool, enabled }: SyncDeps) => {
+  if (!enabled) {
+    return undefined;
+  }
+
+  return {
+    user: {
+      create: {
+        after: async (user: BetterAuthUserLike) => {
+          try {
+            await pool.query(
+              `INSERT INTO public.app_user_profile (auth_user_id, email, display_name, phone_number, created_at)
+               VALUES ($1, $2, $3, $4, NOW())
+               ON CONFLICT (auth_user_id) DO NOTHING`,
+              [user.id, user.email ?? null, user.name ?? null, user.phoneNumber ?? null],
+            );
+          } catch (err) {
+            console.error("[app-user-sync] failed to upsert app_user_profile", err);
+          }
+        },
+      },
+      update: {
+        after: async (user: BetterAuthUserLike) => {
+          try {
+            await pool.query(
+              `UPDATE public.app_user_profile
+               SET email = COALESCE($2, email),
+                   display_name = COALESCE($3, display_name),
+                   phone_number = COALESCE($4, phone_number),
+                   updated_at = NOW()
+               WHERE auth_user_id = $1`,
+              [user.id, user.email ?? null, user.name ?? null, user.phoneNumber ?? null],
+            );
+          } catch (err) {
+            console.error("[app-user-sync] failed to update app_user_profile", err);
+          }
+        },
+      },
+    },
+  };
+};

--- a/auth-service/tsconfig.json
+++ b/auth-service/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ES2022",
+    "moduleResolution": "Bundler",
+    "lib": ["ES2022"],
+    "outDir": "./dist",
+    "rootDir": ".",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "declaration": false,
+    "sourceMap": true,
+    "allowSyntheticDefaultImports": true
+  },
+  "include": ["auth.ts", "src/**/*.ts", "scripts/**/*.ts"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/cmd/util.go
+++ b/cmd/util.go
@@ -13,9 +13,20 @@ import (
 	"factorbacktest/internal/util"
 	"fmt"
 	"log"
+	"os"
 
 	_ "github.com/lib/pq"
 )
+
+// betterAuthJwksURL returns the URL the API uses to fetch the Better Auth
+// JWKS. Defaults to the local sidecar that runs alongside the Go binary in
+// the production Fly image.
+func betterAuthJwksURL() string {
+	if v := os.Getenv("BETTER_AUTH_JWKS_URL"); v != "" {
+		return v
+	}
+	return "http://127.0.0.1:3001/api/auth/jwks"
+}
 
 // this is gross sry
 
@@ -172,6 +183,7 @@ func InitializeDependencies(secrets util.Secrets, overrides *api.ApiHandler) (*a
 		StrategyService:              strategyService,
 		StrategySummaryApp:           strategySummaryApp,
 		JwtDecodeToken:               secrets.Jwt,
+		BetterAuthJwksURL:            betterAuthJwksURL(),
 	}
 
 	return apiHandler, nil

--- a/cmd/util.go
+++ b/cmd/util.go
@@ -28,6 +28,17 @@ func betterAuthJwksURL() string {
 	return "http://127.0.0.1:3001/api/auth/jwks"
 }
 
+// betterAuthExpectedIssuer returns the `iss` claim the Go middleware will
+// require on Better Auth JWTs. Better Auth stamps `iss = baseURL`, so we
+// pull it from the same env var the auth-service uses (APP_BASE_URL).
+// Empty disables the check.
+func betterAuthExpectedIssuer() string {
+	if v := os.Getenv("BETTER_AUTH_EXPECTED_ISSUER"); v != "" {
+		return v
+	}
+	return os.Getenv("APP_BASE_URL")
+}
+
 // this is gross sry
 
 func CloseDependencies(handler *api.ApiHandler) {
@@ -184,6 +195,7 @@ func InitializeDependencies(secrets util.Secrets, overrides *api.ApiHandler) (*a
 		StrategySummaryApp:           strategySummaryApp,
 		JwtDecodeToken:               secrets.Jwt,
 		BetterAuthJwksURL:            betterAuthJwksURL(),
+		BetterAuthExpectedIssuer:     betterAuthExpectedIssuer(),
 	}
 
 	return apiHandler, nil

--- a/fly.toml
+++ b/fly.toml
@@ -16,10 +16,10 @@ primary_region = "iad"
   AUTH_DB_SCHEMA        = "auth"
   TRUSTED_ORIGINS       = "https://factorbacktest.fly.dev,https://factor.trade,https://www.factor.trade"
   FEATURE_GOOGLE        = "true"
-  FEATURE_EMAIL_OTP     = "true"
+  FEATURE_EMAIL_OTP     = "false"   # parity with Supabase setup; flip on once Resend/SES is wired
   FEATURE_SMS_OTP       = "true"
-  EMAIL_PROVIDER        = "resend"
-  EMAIL_FROM            = "Factor.trade <noreply@factor.trade>"
+  EMAIL_PROVIDER        = "console" # unused while FEATURE_EMAIL_OTP=false
+  EMAIL_FROM            = "no-reply@factor.trade"
   SMS_PROVIDER          = "twilio"
   APP_USER_SYNC_ENABLED = "false"
 

--- a/fly.toml
+++ b/fly.toml
@@ -12,9 +12,9 @@ primary_region = "iad"
   # (betterAuthSecret, googleClientSecret, resendApiKey, twilioAuthToken,
   # twilioAccountSid) are set via `flyctl secrets set` using the same
   # camelCase names already used for the rest of the app's secrets.
-  APP_BASE_URL          = "https://factorbacktest.fly.dev"
+  APP_BASE_URL          = "https://api.factor.trade"
   AUTH_DB_SCHEMA        = "auth"
-  TRUSTED_ORIGINS       = "https://factorbacktest.fly.dev,https://factor.trade,https://www.factor.trade"
+  TRUSTED_ORIGINS       = "https://factor.trade,https://www.factor.trade,https://api.factor.trade,https://factorbacktest.fly.dev"
   FEATURE_GOOGLE        = "true"
   FEATURE_EMAIL_OTP     = "false"   # parity with Supabase setup; flip on once Resend/SES is wired
   FEATURE_SMS_OTP       = "true"

--- a/fly.toml
+++ b/fly.toml
@@ -8,6 +8,21 @@ primary_region = "iad"
   FB_SECRETS_FROM_ENV = "1"
   GIN_MODE = "release"
 
+  # Embedded Better Auth sidecar — non-secret configuration. Real secrets
+  # (betterAuthSecret, googleClientSecret, resendApiKey, twilioAuthToken,
+  # twilioAccountSid) are set via `flyctl secrets set` using the same
+  # camelCase names already used for the rest of the app's secrets.
+  APP_BASE_URL          = "https://factorbacktest.fly.dev"
+  AUTH_DB_SCHEMA        = "auth"
+  TRUSTED_ORIGINS       = "https://factorbacktest.fly.dev,https://factor.trade,https://www.factor.trade"
+  FEATURE_GOOGLE        = "true"
+  FEATURE_EMAIL_OTP     = "true"
+  FEATURE_SMS_OTP       = "true"
+  EMAIL_PROVIDER        = "resend"
+  EMAIL_FROM            = "Factor.trade <noreply@factor.trade>"
+  SMS_PROVIDER          = "twilio"
+  APP_USER_SYNC_ENABLED = "false"
+
 [http_service]
   internal_port = 3009
   force_https = true

--- a/frontend/.npmrc
+++ b/frontend/.npmrc
@@ -1,0 +1,5 @@
+; react-scripts 5 declares a peerOptional on typescript ^3 || ^4, but
+; better-auth's type defs require typescript >= 5. The conflict is benign
+; (react-scripts only uses TypeScript via fork-ts-checker, which does
+; accept TS 5), so opt into legacy resolution to keep `npm ci` working.
+legacy-peer-deps=true

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -26,6 +26,7 @@
         "@types/react": "^18.2.21",
         "@types/react-dom": "^18.2.7",
         "@types/uuid": "^9.0.3",
+        "better-auth": "^1.6.9",
         "bootstrap": "^5.3.3",
         "chart.js": "^4.3.3",
         "class-variance-authority": "^0.7.0",
@@ -43,7 +44,6 @@
         "react-tooltip": "^5.21.3",
         "tailwind-merge": "^2.5.2",
         "tailwindcss-animate": "^1.0.7",
-        "typescript": "^4.9.5",
         "typescript-plugin-css-modules": "^5.1.0",
         "uuid": "^9.0.0",
         "web-vitals": "^2.1.4"
@@ -52,7 +52,8 @@
         "@playwright/test": "^1.59.1",
         "react-router-dom": "^6.22.3",
         "serve": "^14.2.6",
-        "tailwindcss": "^3.4.9"
+        "tailwindcss": "^3.4.9",
+        "typescript": "^5.9.3"
       }
     },
     "node_modules/@adobe/css-tools": {
@@ -2259,6 +2260,102 @@
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
       "license": "MIT"
     },
+    "node_modules/@better-auth/core": {
+      "version": "1.6.9",
+      "resolved": "https://registry.npmjs.org/@better-auth/core/-/core-1.6.9.tgz",
+      "integrity": "sha512-ADFk5pwmLybmc+LvYvXJ6M1x2oY/EyYLkwLuH0x28FUq12DfjL0wnE7g+WRDf3yozDO+qIxTpFGXDGwLKbfz0w==",
+      "license": "MIT",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "^1.39.0",
+        "@standard-schema/spec": "^1.1.0",
+        "zod": "^4.3.6"
+      },
+      "peerDependencies": {
+        "@better-auth/utils": "0.4.0",
+        "@better-fetch/fetch": "1.1.21",
+        "@cloudflare/workers-types": ">=4",
+        "@opentelemetry/api": "^1.9.0",
+        "better-call": "1.3.5",
+        "jose": "^6.1.0",
+        "kysely": "^0.28.5",
+        "nanostores": "^1.0.1"
+      },
+      "peerDependenciesMeta": {
+        "@cloudflare/workers-types": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@better-auth/kysely-adapter": {
+      "version": "1.6.9",
+      "resolved": "https://registry.npmjs.org/@better-auth/kysely-adapter/-/kysely-adapter-1.6.9.tgz",
+      "integrity": "sha512-gyjuuxJtZ4o9G9z9q4kqn24X2kvMSp7F+KHogYxF03SnXY/2WleAcuj57iC4wP3e9mGDbjPOrnM5K6Kr3Ktdpw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@better-auth/core": "^1.6.9",
+        "@better-auth/utils": "0.4.0",
+        "kysely": "^0.28.14"
+      },
+      "peerDependenciesMeta": {
+        "kysely": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@better-auth/memory-adapter": {
+      "version": "1.6.9",
+      "resolved": "https://registry.npmjs.org/@better-auth/memory-adapter/-/memory-adapter-1.6.9.tgz",
+      "integrity": "sha512-XmIG4tUnOXZ+KEcWjHUjOI9Z5donD09dC2t/AQTXifAUIqx7cySg86w0KTM09ArzAxRx1fCqO36Wkt5nULnrkQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@better-auth/core": "^1.6.9",
+        "@better-auth/utils": "0.4.0"
+      }
+    },
+    "node_modules/@better-auth/mongo-adapter": {
+      "version": "1.6.9",
+      "resolved": "https://registry.npmjs.org/@better-auth/mongo-adapter/-/mongo-adapter-1.6.9.tgz",
+      "integrity": "sha512-h+AiRJ/TsBSi+ZDjySASBpbJ/9QCXBre34PSKgCz7QmTHrFM9Cg2EM4AM7LjR5lPXipEE+2rWPBc9wfnUBjhcw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@better-auth/core": "^1.6.9",
+        "@better-auth/utils": "0.4.0",
+        "mongodb": "^6.0.0 || ^7.0.0"
+      },
+      "peerDependenciesMeta": {
+        "mongodb": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@better-auth/telemetry": {
+      "version": "1.6.9",
+      "resolved": "https://registry.npmjs.org/@better-auth/telemetry/-/telemetry-1.6.9.tgz",
+      "integrity": "sha512-0u5zkhSCAQFoN3DHvUkLHOF6MBbVTDAa6mU8mhPwiysdz1x21vMzhzfaAKN/ZGWaQ09v91/F+2qu42G/bhUV4A==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@better-auth/core": "^1.6.9",
+        "@better-auth/utils": "0.4.0",
+        "@better-fetch/fetch": "1.1.21"
+      }
+    },
+    "node_modules/@better-auth/utils": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@better-auth/utils/-/utils-0.4.0.tgz",
+      "integrity": "sha512-RpMtLUIQAEWMgdPLNVbIF5ON2mm+CH0U3rCdUCU1VyeAUui4m38DyK7/aXMLZov2YDjG684pS1D0MBllrmgjQA==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "^2.0.1"
+      }
+    },
+    "node_modules/@better-fetch/fetch": {
+      "version": "1.1.21",
+      "resolved": "https://registry.npmjs.org/@better-fetch/fetch/-/fetch-1.1.21.tgz",
+      "integrity": "sha512-/ImESw0sskqlVR94jB+5+Pxjf+xBwDZF/N5+y2/q4EqD7IARUTSpPfIo8uf39SYpCxyOCtbyYpUrZ3F/k0zT4A=="
+    },
     "node_modules/@csstools/normalize.css": {
       "version": "12.1.1",
       "resolved": "https://registry.npmjs.org/@csstools/normalize.css/-/normalize.css-12.1.1.tgz",
@@ -3267,6 +3364,30 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/@noble/ciphers": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@noble/ciphers/-/ciphers-2.2.0.tgz",
+      "integrity": "sha512-Z6pjIZ/8IJcCGzb2S/0Px5J81yij85xASuk1teLNeg75bfT07MV3a/O2Mtn1I2se43k3lkVEcFaR10N4cgQcZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@noble/hashes": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.2.0.tgz",
+      "integrity": "sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -3300,6 +3421,15 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.40.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.40.0.tgz",
+      "integrity": "sha512-cifvXDhcqMwwTlTK04GBNeIe7yyo28Mfby85QXFe1Yk8nmi36Ab/5UQwptOx84SsoGNRg+EVSjwzfSZMy6pmlw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/@pkgjs/parseargs": {
@@ -4074,6 +4204,12 @@
       "dependencies": {
         "@sinonjs/commons": "^1.7.0"
       }
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "license": "MIT"
     },
     "node_modules/@supabase/auth-js": {
       "version": "2.64.4",
@@ -6223,6 +6359,167 @@
       "integrity": "sha512-x+VAiMRL6UPkx+kudNvxTl6hB2XNNCG2r+7wixVfIYwu/2HKRXimwQyaumLjMveWvT2Hkd/cAJw+QBMfJ/EKVw==",
       "license": "MIT"
     },
+    "node_modules/better-auth": {
+      "version": "1.6.9",
+      "resolved": "https://registry.npmjs.org/better-auth/-/better-auth-1.6.9.tgz",
+      "integrity": "sha512-EBFURtglyiEZxbx4NJBoqUD8J65dX24yC+6I9AUbIXNgUkt76mshzGbHkxZ3n/lB7Dwq3kBC+hHt0hUQsnL7HA==",
+      "license": "MIT",
+      "dependencies": {
+        "@better-auth/core": "1.6.9",
+        "@better-auth/drizzle-adapter": "1.6.9",
+        "@better-auth/kysely-adapter": "1.6.9",
+        "@better-auth/memory-adapter": "1.6.9",
+        "@better-auth/mongo-adapter": "1.6.9",
+        "@better-auth/prisma-adapter": "1.6.9",
+        "@better-auth/telemetry": "1.6.9",
+        "@better-auth/utils": "0.4.0",
+        "@better-fetch/fetch": "1.1.21",
+        "@noble/ciphers": "^2.1.1",
+        "@noble/hashes": "^2.0.1",
+        "better-call": "1.3.5",
+        "defu": "^6.1.4",
+        "jose": "^6.1.3",
+        "kysely": "^0.28.14",
+        "nanostores": "^1.1.1",
+        "zod": "^4.3.6"
+      },
+      "peerDependencies": {
+        "@lynx-js/react": "*",
+        "@prisma/client": "^5.0.0 || ^6.0.0 || ^7.0.0",
+        "@sveltejs/kit": "^2.0.0",
+        "@tanstack/react-start": "^1.0.0",
+        "@tanstack/solid-start": "^1.0.0",
+        "better-sqlite3": "^12.0.0",
+        "drizzle-kit": ">=0.31.4",
+        "drizzle-orm": "^0.45.2",
+        "mongodb": "^6.0.0 || ^7.0.0",
+        "mysql2": "^3.0.0",
+        "next": "^14.0.0 || ^15.0.0 || ^16.0.0",
+        "pg": "^8.0.0",
+        "prisma": "^5.0.0 || ^6.0.0 || ^7.0.0",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0",
+        "solid-js": "^1.0.0",
+        "svelte": "^4.0.0 || ^5.0.0",
+        "vitest": "^2.0.0 || ^3.0.0 || ^4.0.0",
+        "vue": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@lynx-js/react": {
+          "optional": true
+        },
+        "@prisma/client": {
+          "optional": true
+        },
+        "@sveltejs/kit": {
+          "optional": true
+        },
+        "@tanstack/react-start": {
+          "optional": true
+        },
+        "@tanstack/solid-start": {
+          "optional": true
+        },
+        "better-sqlite3": {
+          "optional": true
+        },
+        "drizzle-kit": {
+          "optional": true
+        },
+        "drizzle-orm": {
+          "optional": true
+        },
+        "mongodb": {
+          "optional": true
+        },
+        "mysql2": {
+          "optional": true
+        },
+        "next": {
+          "optional": true
+        },
+        "pg": {
+          "optional": true
+        },
+        "prisma": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        },
+        "solid-js": {
+          "optional": true
+        },
+        "svelte": {
+          "optional": true
+        },
+        "vitest": {
+          "optional": true
+        },
+        "vue": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/better-auth/node_modules/@better-auth/drizzle-adapter": {
+      "version": "1.6.9",
+      "resolved": "https://registry.npmjs.org/@better-auth/drizzle-adapter/-/drizzle-adapter-1.6.9.tgz",
+      "integrity": "sha512-Lcco5hOGrMgc4XKAkvB6x72eQm4wCcya8IevMg4wBHY9W9GVg8pu23rpRX6VsVQSO4Ux13S7lFwUWtF7/r9aKw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@better-auth/core": "^1.6.9",
+        "@better-auth/utils": "0.4.0",
+        "drizzle-orm": "^0.45.2"
+      },
+      "peerDependenciesMeta": {
+        "drizzle-orm": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/better-auth/node_modules/@better-auth/prisma-adapter": {
+      "version": "1.6.9",
+      "resolved": "https://registry.npmjs.org/@better-auth/prisma-adapter/-/prisma-adapter-1.6.9.tgz",
+      "integrity": "sha512-XHks01ntK20orqK/jICq8wmEbJ/zT6dct49Fk8zTQKN9QNGDc+Ix5+7z/Kvui0DXGFf790GfvRozquzaLtXa8Q==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@better-auth/core": "^1.6.9",
+        "@better-auth/utils": "0.4.0",
+        "@prisma/client": "^5.0.0 || ^6.0.0 || ^7.0.0",
+        "prisma": "^5.0.0 || ^6.0.0 || ^7.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@prisma/client": {
+          "optional": true
+        },
+        "prisma": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/better-call": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/better-call/-/better-call-1.3.5.tgz",
+      "integrity": "sha512-kOFJkBP7utAQLEYrobZm3vkTH8mXq5GNgvjc5/XEST1ilVHaxXUXfeDeFlqoETMtyqS4+3/h4ONX2i++ebZrvA==",
+      "license": "MIT",
+      "dependencies": {
+        "@better-auth/utils": "^0.4.0",
+        "@better-fetch/fetch": "^1.1.21",
+        "rou3": "^0.7.12",
+        "set-cookie-parser": "^3.0.1"
+      },
+      "peerDependencies": {
+        "zod": "^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "zod": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/bfj": {
       "version": "7.1.0",
       "resolved": "https://registry.npmjs.org/bfj/-/bfj-7.1.0.tgz",
@@ -7933,6 +8230,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/defu": {
+      "version": "6.1.7",
+      "resolved": "https://registry.npmjs.org/defu/-/defu-6.1.7.tgz",
+      "integrity": "sha512-7z22QmUWiQ/2d0KkdYmANbRUVABpZ9SNYyH5vx6PZ+nE5bcC0l7uFvEfHlyld/HcGBFTL536ClDt3DEcSlEJAQ==",
+      "license": "MIT"
     },
     "node_modules/delayed-stream": {
       "version": "1.0.0",
@@ -12316,6 +12619,15 @@
         "jiti": "bin/jiti.js"
       }
     },
+    "node_modules/jose": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.2.tgz",
+      "integrity": "sha512-d7kPDd34KO/YnzaDOlikGpOurfF0ByC2sEV4cANCtdqLlTfBlw2p14O/5d/zv40gJPbIQxfES3nSx1/oYNyuZQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -12741,6 +13053,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/kysely": {
+      "version": "0.28.16",
+      "resolved": "https://registry.npmjs.org/kysely/-/kysely-0.28.16.tgz",
+      "integrity": "sha512-3i5pmOiZvMDj00qhrIVbH0AnioVTx22DMP7Vn5At4yJO46iy+FM8Y/g61ltenLVSo3fiO8h8Q3QOFgf/gQ72ww==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "node_modules/language-subtag-registry": {
@@ -13292,6 +13613,21 @@
       },
       "engines": {
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/nanostores": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/nanostores/-/nanostores-1.3.0.tgz",
+      "integrity": "sha512-XPUa/jz+P1oJvN9VBxw4L9MtdFfaH3DAryqPssqhb2kXjmb9npz0dly6rCsgFWOPr4Yg9mTfM3MDZgZZ+7A3lA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": "^20.0.0 || >=22.0.0"
       }
     },
     "node_modules/natural-compare": {
@@ -16573,6 +16909,12 @@
         "randombytes": "^2.1.0"
       }
     },
+    "node_modules/rou3": {
+      "version": "0.7.12",
+      "resolved": "https://registry.npmjs.org/rou3/-/rou3-0.7.12.tgz",
+      "integrity": "sha512-iFE4hLDuloSWcD7mjdCDhx2bKcIsYbtOTpfH5MHHLSKMOUyjqQXTeZVa289uuwEGEKFoE/BAPbhaU4B774nceg==",
+      "license": "MIT"
+    },
     "node_modules/run-parallel": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
@@ -17113,6 +17455,12 @@
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/set-cookie-parser": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-3.1.0.tgz",
+      "integrity": "sha512-kjnC1DXBHcxaOaOXBHBeRtltsDG2nUiUni+jP92M9gYdW12rsmx92UsfpH7o5tDRs7I1ZZPSQJQGv3UaRfCiuw==",
       "license": "MIT"
     },
     "node_modules/set-function-length": {
@@ -18667,16 +19015,16 @@
       }
     },
     "node_modules/typescript": {
-      "version": "4.9.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
-      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
       },
       "engines": {
-        "node": ">=4.2.0"
+        "node": ">=14.17"
       }
     },
     "node_modules/typescript-plugin-css-modules": {
@@ -20074,6 +20422,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zod": {
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
+      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     }
   }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -21,6 +21,7 @@
     "@types/react": "^18.2.21",
     "@types/react-dom": "^18.2.7",
     "@types/uuid": "^9.0.3",
+    "better-auth": "^1.6.9",
     "bootstrap": "^5.3.3",
     "chart.js": "^4.3.3",
     "class-variance-authority": "^0.7.0",
@@ -38,7 +39,6 @@
     "react-tooltip": "^5.21.3",
     "tailwind-merge": "^2.5.2",
     "tailwindcss-animate": "^1.0.7",
-    "typescript": "^4.9.5",
     "typescript-plugin-css-modules": "^5.1.0",
     "uuid": "^9.0.0",
     "web-vitals": "^2.1.4"
@@ -72,6 +72,7 @@
     "@playwright/test": "^1.59.1",
     "react-router-dom": "^6.22.3",
     "serve": "^14.2.6",
-    "tailwindcss": "^3.4.9"
+    "tailwindcss": "^3.4.9",
+    "typescript": "^5.9.3"
   }
 }

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -16,11 +16,7 @@ export interface FactorData {
   data: Record<string, BacktestSnapshot>,
 }
 
-export const endpoint = process.env.REACT_APP_API_PORT
-  ? ("http://localhost:" + process.env.REACT_APP_API_PORT)
-  : ((process.env.NODE_ENV === 'production')
-    ? "https://tgwmxgtk07.execute-api.us-east-1.amazonaws.com/prod"
-    : "http://localhost:3009");
+export { endpoint } from './config';
 
 export interface BenchmarkData {
   symbol: string,

--- a/frontend/src/auth.tsx
+++ b/frontend/src/auth.tsx
@@ -1,11 +1,14 @@
 import React, { createContext, useCallback, useContext, useEffect, useMemo, useState } from "react";
 import { createAuthClient } from "better-auth/react";
 import { emailOTPClient, phoneNumberClient } from "better-auth/client/plugins";
+import { endpoint } from "./config";
 
-// The auth-service is mounted at /api/auth on the same domain (same Fly app),
-// so we don't need to pass an explicit baseURL. The Go API reverse-proxies
-// /api/auth/* to the local Better Auth sidecar.
+// The auth-service is mounted at /api/auth on the same domain as the Go API
+// (same Fly machine). In local dev that means localhost:3009, in prod the
+// Fly hostname. We reuse `endpoint` so this stays in sync with every other
+// API call in the app.
 const authClient = createAuthClient({
+  baseURL: endpoint,
   plugins: [emailOTPClient(), phoneNumberClient()],
 });
 
@@ -61,7 +64,7 @@ const AuthContext = createContext<AuthContextValue>({
 
 const fetchAccessToken = async (): Promise<string | null> => {
   try {
-    const resp = await fetch("/api/auth/token", { credentials: "include" });
+    const resp = await fetch(`${endpoint}/api/auth/token`, { credentials: "include" });
     if (!resp.ok) return null;
     const body = (await resp.json()) as { token?: string };
     return body.token ?? null;
@@ -77,20 +80,26 @@ interface AuthProviderProps {
 const AuthProvider = ({ children }: AuthProviderProps) => {
   const { data, isPending, refetch } = authClient.useSession();
   const [accessToken, setAccessToken] = useState<string | null>(null);
+  // Tracks the "I have a session but I'm still fetching the JWT" window so
+  // page-level guards don't briefly see (loading=false, session=null) on
+  // refresh and pop a login modal at an already-authenticated user.
+  const [tokenLoading, setTokenLoading] = useState<boolean>(false);
 
   const sessionUser = data?.user as AppUser | undefined;
 
-  // Refresh the JWT whenever the session user changes (sign-in, sign-out,
-  // or refetch). The JWT is what we attach to API calls to the Go backend.
   const sessionUserId = sessionUser?.id ?? null;
   useEffect(() => {
     let cancelled = false;
     if (!sessionUserId) {
       setAccessToken(null);
+      setTokenLoading(false);
       return;
     }
+    setTokenLoading(true);
     fetchAccessToken().then((token) => {
-      if (!cancelled) setAccessToken(token);
+      if (cancelled) return;
+      setAccessToken(token);
+      setTokenLoading(false);
     });
     return () => {
       cancelled = true;
@@ -147,7 +156,7 @@ const AuthProvider = ({ children }: AuthProviderProps) => {
       : null;
 
   const value: AuthContextValue = {
-    loading: isPending,
+    loading: isPending || tokenLoading,
     user: sessionUser ?? null,
     session,
     signIn,

--- a/frontend/src/auth.tsx
+++ b/frontend/src/auth.tsx
@@ -1,75 +1,163 @@
-import React, { createContext, useContext, useEffect, useState } from 'react';
-import { createClient, Session, SupabaseClient, User } from '@supabase/supabase-js';
+import React, { createContext, useCallback, useContext, useEffect, useMemo, useState } from "react";
+import { createAuthClient } from "better-auth/react";
+import { emailOTPClient, phoneNumberClient } from "better-auth/client/plugins";
 
-const supabaseUrl = process.env.REACT_APP_SUPABASE_URL || "";
-const supabaseKey = process.env.REACT_APP_SUPABASE_ANON_KEY || "";
+// The auth-service is mounted at /api/auth on the same domain (same Fly app),
+// so we don't need to pass an explicit baseURL. The Go API reverse-proxies
+// /api/auth/* to the local Better Auth sidecar.
+const authClient = createAuthClient({
+  plugins: [emailOTPClient(), phoneNumberClient()],
+});
 
-const supabase: SupabaseClient = createClient(supabaseUrl, supabaseKey);
+// Shape kept compatible with existing call sites (`session.access_token`,
+// `session.user.id`, etc.) so the wider app didn't have to change. The
+// access token is fetched on demand from Better Auth's JWT plugin endpoint.
+export interface AppUser {
+  id: string;
+  email?: string | null;
+  phoneNumber?: string | null;
+  name?: string | null;
+  image?: string | null;
+}
+
+export interface AppSession {
+  access_token: string;
+  user: AppUser;
+}
+
+interface SignInApi {
+  google: () => Promise<void>;
+  sendEmailOtp: (email: string) => Promise<void>;
+  verifyEmailOtp: (email: string, otp: string) => Promise<void>;
+  sendSmsOtp: (phoneNumber: string) => Promise<void>;
+  verifySmsOtp: (phoneNumber: string, code: string) => Promise<void>;
+}
+
+interface AuthContextValue {
+  loading: boolean;
+  user: AppUser | null;
+  session: AppSession | null;
+  signIn: SignInApi;
+  signOut: () => Promise<void>;
+  refreshToken: () => Promise<string | null>;
+}
+
+const defaultSignIn: SignInApi = {
+  google: async () => {},
+  sendEmailOtp: async () => {},
+  verifyEmailOtp: async () => {},
+  sendSmsOtp: async () => {},
+  verifySmsOtp: async () => {},
+};
+
+const AuthContext = createContext<AuthContextValue>({
+  loading: true,
+  user: null,
+  session: null,
+  signIn: defaultSignIn,
+  signOut: async () => {},
+  refreshToken: async () => null,
+});
+
+const fetchAccessToken = async (): Promise<string | null> => {
+  try {
+    const resp = await fetch("/api/auth/token", { credentials: "include" });
+    if (!resp.ok) return null;
+    const body = (await resp.json()) as { token?: string };
+    return body.token ?? null;
+  } catch {
+    return null;
+  }
+};
 
 interface AuthProviderProps {
-  children: React.ReactNode
+  children: React.ReactNode;
 }
 
-type AuthContextType = {
-  loading: boolean,
-  session: Session | null,
-  user: User | null
-  supabase: SupabaseClient | null
-}
+const AuthProvider = ({ children }: AuthProviderProps) => {
+  const { data, isPending, refetch } = authClient.useSession();
+  const [accessToken, setAccessToken] = useState<string | null>(null);
 
-const AuthContext = createContext<AuthContextType>({
-  loading: true,
-  session: null,
-  user: null,
-  supabase: null,
-})
+  const sessionUser = data?.user as AppUser | undefined;
 
-const AuthProvider = (props: AuthProviderProps) => {
-  const [user, setUser] = useState<User | null>(null)
-  const [session, setSession] = useState<Session | null>(null)
-  const [loading, setLoading] = useState<boolean>(true)
-
+  // Refresh the JWT whenever the session user changes (sign-in, sign-out,
+  // or refetch). The JWT is what we attach to API calls to the Go backend.
+  const sessionUserId = sessionUser?.id ?? null;
   useEffect(() => {
-    const { data: listener } = supabase.auth.onAuthStateChange((_event, session) => {
-      setSession(session)
-      setUser(session?.user || null)
-      setLoading(false)
-    })
-
-    const setData = async () => {
-      const { data: { session }, error } = await supabase.auth.getSession()
-      if (error) {
-        throw error
-      }
-
-      setSession(session)
-      setUser(session?.user || null)
-      setLoading(false)
+    let cancelled = false;
+    if (!sessionUserId) {
+      setAccessToken(null);
+      return;
     }
-
-    setData()
-
+    fetchAccessToken().then((token) => {
+      if (!cancelled) setAccessToken(token);
+    });
     return () => {
-      listener?.subscription.unsubscribe()
-    }
-  }, [])
+      cancelled = true;
+    };
+  }, [sessionUserId]);
 
-  const value = {
-    loading,
+  const refreshToken = useCallback(async () => {
+    const token = await fetchAccessToken();
+    setAccessToken(token);
+    return token;
+  }, []);
+
+  const signOut = useCallback(async () => {
+    await authClient.signOut();
+    await refetch();
+  }, [refetch]);
+
+  const signIn: SignInApi = useMemo(
+    () => ({
+      google: async () => {
+        await authClient.signIn.social({
+          provider: "google",
+          callbackURL: window.location.href,
+        });
+      },
+      sendEmailOtp: async (email) => {
+        const { error } = await authClient.emailOtp.sendVerificationOtp({
+          email,
+          type: "sign-in",
+        });
+        if (error) throw new Error(error.message ?? "failed to send email OTP");
+      },
+      verifyEmailOtp: async (email, otp) => {
+        const { error } = await authClient.signIn.emailOtp({ email, otp });
+        if (error) throw new Error(error.message ?? "invalid email OTP");
+        await refetch();
+      },
+      sendSmsOtp: async (phoneNumber) => {
+        const { error } = await authClient.phoneNumber.sendOtp({ phoneNumber });
+        if (error) throw new Error(error.message ?? "failed to send SMS OTP");
+      },
+      verifySmsOtp: async (phoneNumber, code) => {
+        const { error } = await authClient.phoneNumber.verify({ phoneNumber, code });
+        if (error) throw new Error(error.message ?? "invalid SMS OTP");
+        await refetch();
+      },
+    }),
+    [refetch],
+  );
+
+  const session: AppSession | null =
+    sessionUser && accessToken
+      ? { access_token: accessToken, user: sessionUser }
+      : null;
+
+  const value: AuthContextValue = {
+    loading: isPending,
+    user: sessionUser ?? null,
     session,
-    user,
-    supabase,
-  }
+    signIn,
+    signOut,
+    refreshToken,
+  };
 
-  return (
-    <AuthContext.Provider value={value}>
-      {props.children}
-    </AuthContext.Provider>
-  )
-}
+  return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;
+};
 
-export const useAuth = () => {
-  return useContext(AuthContext)
-}
+export const useAuth = () => useContext(AuthContext);
 
-export default AuthProvider
+export default AuthProvider;

--- a/frontend/src/auth.tsx
+++ b/frontend/src/auth.tsx
@@ -40,6 +40,10 @@ interface AuthContextValue {
   loading: boolean;
   user: AppUser | null;
   session: AppSession | null;
+  // True iff Better Auth knows about a user but we couldn't fetch the JWT
+  // we need to call protected APIs. Distinct from "logged out" (user==null)
+  // and from "still loading" (loading==true).
+  tokenError: boolean;
   signIn: SignInApi;
   signOut: () => Promise<void>;
   refreshToken: () => Promise<string | null>;
@@ -57,6 +61,7 @@ const AuthContext = createContext<AuthContextValue>({
   loading: true,
   user: null,
   session: null,
+  tokenError: false,
   signIn: defaultSignIn,
   signOut: async () => {},
   refreshToken: async () => null,
@@ -100,6 +105,15 @@ const AuthProvider = ({ children }: AuthProviderProps) => {
       if (cancelled) return;
       setAccessToken(token);
       setTokenLoading(false);
+      if (!token) {
+        // User is logged in (server knows them) but we couldn't get a JWT.
+        // Most likely cause: cross-origin cookie blocked by the browser.
+        // Surface in console so a developer notices, and `tokenError`
+        // exposes the state to consumers (so they can show a banner or
+        // force a re-auth instead of looking superficially logged in).
+        // eslint-disable-next-line no-console
+        console.warn("[auth] session present but JWT fetch failed");
+      }
     });
     return () => {
       cancelled = true;
@@ -155,10 +169,13 @@ const AuthProvider = ({ children }: AuthProviderProps) => {
       ? { access_token: accessToken, user: sessionUser }
       : null;
 
+  const tokenError = Boolean(sessionUserId) && !tokenLoading && !accessToken;
+
   const value: AuthContextValue = {
     loading: isPending || tokenLoading,
     user: sessionUser ?? null,
     session,
+    tokenError,
     signIn,
     signOut,
     refreshToken,

--- a/frontend/src/common/AuthModals.tsx
+++ b/frontend/src/common/AuthModals.tsx
@@ -34,6 +34,7 @@ export default function LoginModal({
   const [error, setError] = useState<string>("");
 
   const handleGoogle = async () => {
+    if (loading) return;
     setError("");
     setLoading(true);
     try {
@@ -108,6 +109,7 @@ export default function LoginModal({
             onGoogle={handleGoogle}
             onSmsRequest={handleSmsRequest}
             onEmailRequest={handleEmailRequest}
+            loading={loading}
           />
         )}
 
@@ -165,6 +167,7 @@ function InitialPanel({
   onGoogle,
   onSmsRequest,
   onEmailRequest,
+  loading,
 }: {
   email: string;
   setEmail: (v: string) => void;
@@ -173,10 +176,11 @@ function InitialPanel({
   onGoogle: () => void;
   onSmsRequest: (e: React.FormEvent<HTMLFormElement>) => void;
   onEmailRequest: (e: React.FormEvent<HTMLFormElement>) => void;
+  loading: boolean;
 }) {
   return (
     <>
-      <Button onClick={onGoogle} type="button" className="w-full">
+      <Button onClick={onGoogle} type="button" className="w-full" disabled={loading}>
         Continue with Google
       </Button>
 
@@ -194,7 +198,7 @@ function InitialPanel({
               onChange={(e) => setEmail(e.target.value)}
             />
           </div>
-          <Button disabled={!email.includes("@")} type="submit" className="w-full">
+          <Button disabled={loading || !email.includes("@")} type="submit" className="w-full">
             Email me a code
           </Button>
         </div>
@@ -218,7 +222,7 @@ function InitialPanel({
             />
           </div>
           <Button
-            disabled={!isValidPhoneNumber(phoneNumber || "", "US")}
+            disabled={loading || !isValidPhoneNumber(phoneNumber || "", "US")}
             type="submit"
             className="w-full"
           >
@@ -254,14 +258,19 @@ function SmsConfirmationPanel({
 }) {
   const { signIn } = useAuth();
   const [code, setCode] = useState("");
+  const [submitting, setSubmitting] = useState(false);
 
   const onSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
+    if (submitting) return;
+    setSubmitting(true);
     try {
       await signIn.verifySmsOtp(phoneNumber, code);
       onSuccess();
     } catch (err: unknown) {
       setError(err instanceof Error ? err.message : "Invalid code");
+    } finally {
+      setSubmitting(false);
     }
   };
 
@@ -281,7 +290,7 @@ function SmsConfirmationPanel({
             }}
           />
         </div>
-        <Button disabled={code.length !== 6} type="submit" className="w-full">
+        <Button disabled={submitting || code.length !== 6} type="submit" className="w-full">
           Continue
         </Button>
       </div>
@@ -300,14 +309,19 @@ function EmailConfirmationPanel({
 }) {
   const { signIn } = useAuth();
   const [code, setCode] = useState("");
+  const [submitting, setSubmitting] = useState(false);
 
   const onSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
+    if (submitting) return;
+    setSubmitting(true);
     try {
       await signIn.verifyEmailOtp(email, code);
       onSuccess();
     } catch (err: unknown) {
       setError(err instanceof Error ? err.message : "Invalid code");
+    } finally {
+      setSubmitting(false);
     }
   };
 
@@ -327,7 +341,7 @@ function EmailConfirmationPanel({
             }}
           />
         </div>
-        <Button disabled={code.length !== 6} type="submit" className="w-full">
+        <Button disabled={submitting || code.length !== 6} type="submit" className="w-full">
           Continue
         </Button>
       </div>

--- a/frontend/src/common/AuthModals.tsx
+++ b/frontend/src/common/AuthModals.tsx
@@ -1,8 +1,5 @@
 import { useState } from "react";
 import { useAuth } from "auth";
-import modalsStyle from "./Modals.module.css";
-import { GoogleLogin } from "@react-oauth/google";
-import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Label } from "@/components/ui/label";
 import PhoneInput, { isValidPhoneNumber } from "react-phone-number-input/input";
@@ -10,255 +7,330 @@ import PhoneInput, { isValidPhoneNumber } from "react-phone-number-input/input";
 import {
   Dialog,
   DialogContent,
-  DialogFooter,
   DialogHeader,
   DialogTitle,
-} from "@/components/ui/dialog"
+} from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
 import { cn } from "@/lib/utils";
-import { SupabaseClient } from "@supabase/supabase-js";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { AlertCircle } from "lucide-react";
-import { Turnstile } from '@marsidev/react-turnstile'
 
+type PageState = "initial" | "smsConfirmation" | "emailConfirmation";
 
 export default function LoginModal({
   show,
   close,
-  onSuccess
-}: { show: boolean, close: () => void, onSuccess?: () => void }) {
-  // create enum for page
-  type PageState = "initial" | "phoneConfirmation"
-  const { supabase } = useAuth()
-  const [phoneNumber, setPhoneNumber] = useState<any>("");
+  onSuccess,
+}: {
+  show: boolean;
+  close: () => void;
+  onSuccess?: () => void;
+}) {
+  const { signIn } = useAuth();
   const [pageState, setPageState] = useState<PageState>("initial");
+  const [phoneNumber, setPhoneNumber] = useState<string>("");
+  const [email, setEmail] = useState<string>("");
   const [loading, setLoading] = useState<boolean>(false);
   const [error, setError] = useState<string>("");
-  const [captchaToken, setCaptchaToken] = useState("")
 
-  if (!supabase) {
-    return null;
-  }
+  const handleGoogle = async () => {
+    setError("");
+    setLoading(true);
+    try {
+      await signIn.google();
+      onSuccess?.();
+      close();
+    } catch (e: unknown) {
+      setError(e instanceof Error ? e.message : "Google sign-in failed");
+    } finally {
+      setLoading(false);
+    }
+  };
 
-  const handleFormSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
+  const handleSmsRequest = async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
     setLoading(true);
     setError("");
-    const { data, error } = await supabase.auth.signInWithOtp({
-      phone: phoneNumber,
-      options: {
-        captchaToken,
-      }
-    })
-    if (error) {
-      setError(error.message)
-      setLoading(false)
-    } else {
-      setLoading(false)
-      setPageState("phoneConfirmation")
+    try {
+      await signIn.sendSmsOtp(phoneNumber);
+      setPageState("smsConfirmation");
+    } catch (e: unknown) {
+      setError(e instanceof Error ? e.message : "Failed to send SMS code");
+    } finally {
+      setLoading(false);
     }
-  }
+  };
+
+  const handleEmailRequest = async (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    setLoading(true);
+    setError("");
+    try {
+      await signIn.sendEmailOtp(email);
+      setPageState("emailConfirmation");
+    } catch (e: unknown) {
+      setError(e instanceof Error ? e.message : "Failed to send email code");
+    } finally {
+      setLoading(false);
+    }
+  };
 
   return (
-    <Dialog open={show} onOpenChange={(c) => { if (!c) { close() } }}>
+    <Dialog
+      open={show}
+      onOpenChange={(open) => {
+        if (!open) {
+          setPageState("initial");
+          setError("");
+          close();
+        }
+      }}
+    >
       <DialogContent className="sm:max-w-[425px] grid gap-4 p-10 pt-3">
         <DialogHeader className="text-left">
           <DialogTitle className="mb-0 text-center">Login</DialogTitle>
-          {/* <CardDescription>
-              Use your phone number or Google account.
-            </CardDescription> */}
         </DialogHeader>
 
-        {error ?
+        {error && (
           <Alert className="pb-3 pt-0" variant="destructive">
             <AlertCircle className="h-4 w-4" />
             <AlertTitle className="mt-2 text-lg">Error</AlertTitle>
-            <AlertDescription>
-              {error}
-            </AlertDescription>
+            <AlertDescription>{error}</AlertDescription>
           </Alert>
-          : null}
-        {pageState === "initial" ? <InitialLoginDialog
-          supabase={supabase}
-          handleFormSubmit={handleFormSubmit}
-          phoneNumber={phoneNumber}
-          setPhoneNumber={setPhoneNumber}
-          close={close}
-          onSuccess={onSuccess}
-          captchaToken={captchaToken}
-          setCaptchaToken={setCaptchaToken}
-        /> : <PhoneConfirmationDialog
-          supabase={supabase}
-          phoneNumber={phoneNumber}
-          close={close}
-          setError={setError}
-          onSuccess={onSuccess}
-        />}
+        )}
 
-        {loading && <div className="flex justify-center">
-          <div className="animate-caret">
-            <span className="sr-only">Loading...</span>
-            <svg className="h-6 w-6 animate-spin fill-primary-foreground" viewBox="0 0 24 24">
-              <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4"></circle>
-              <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
-            </svg>
-          </div>
-        </div>}
+        {pageState === "initial" && (
+          <InitialPanel
+            email={email}
+            setEmail={setEmail}
+            phoneNumber={phoneNumber}
+            setPhoneNumber={setPhoneNumber}
+            onGoogle={handleGoogle}
+            onSmsRequest={handleSmsRequest}
+            onEmailRequest={handleEmailRequest}
+          />
+        )}
+
+        {pageState === "smsConfirmation" && (
+          <SmsConfirmationPanel
+            phoneNumber={phoneNumber}
+            setError={setError}
+            onSuccess={() => {
+              onSuccess?.();
+              close();
+            }}
+          />
+        )}
+
+        {pageState === "emailConfirmation" && (
+          <EmailConfirmationPanel
+            email={email}
+            setError={setError}
+            onSuccess={() => {
+              onSuccess?.();
+              close();
+            }}
+          />
+        )}
+
+        {loading && <Spinner />}
       </DialogContent>
-    </Dialog >
-  )
+    </Dialog>
+  );
 }
 
-function InitialLoginDialog({
-  supabase,
-  handleFormSubmit,
+function Spinner() {
+  return (
+    <div className="flex justify-center">
+      <div className="animate-caret">
+        <span className="sr-only">Loading...</span>
+        <svg className="h-6 w-6 animate-spin fill-primary-foreground" viewBox="0 0 24 24">
+          <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
+          <path
+            className="opacity-75"
+            fill="currentColor"
+            d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
+          />
+        </svg>
+      </div>
+    </div>
+  );
+}
+
+function InitialPanel({
+  email,
+  setEmail,
   phoneNumber,
   setPhoneNumber,
-  close,
-  onSuccess,
-  captchaToken,
-  setCaptchaToken
+  onGoogle,
+  onSmsRequest,
+  onEmailRequest,
 }: {
-  supabase: SupabaseClient,
-  handleFormSubmit: (e: React.FormEvent<HTMLFormElement>) => void,
-  phoneNumber: any,
-  setPhoneNumber: (phoneNumber: any) => void,
-  close: () => void,
-  onSuccess?: () => void
-  captchaToken: string,
-  setCaptchaToken: React.Dispatch<React.SetStateAction<string>>
+  email: string;
+  setEmail: (v: string) => void;
+  phoneNumber: string;
+  setPhoneNumber: (v: any) => void;
+  onGoogle: () => void;
+  onSmsRequest: (e: React.FormEvent<HTMLFormElement>) => void;
+  onEmailRequest: (e: React.FormEvent<HTMLFormElement>) => void;
 }) {
-  return (<>
-    <div className="block flex justify-center">
-      <GoogleLogin
-        width={"100%"}
-        onSuccess={credentialResponse => {
-          if (credentialResponse.credential) {
-            supabase.auth.signInWithIdToken({
-              provider: 'google',
-              token: credentialResponse.credential,
-            })
-            onSuccess && onSuccess()
-            close()
-          } else {
-            alert("Failed to login with Google")
-          }
-        }}
-        onError={() => {
-          alert("Failed to login with Google")
-        }}
-      />
-    </div>
+  return (
+    <>
+      <Button onClick={onGoogle} type="button" className="w-full">
+        Continue with Google
+      </Button>
 
+      <Divider label="or email" />
+
+      <form onSubmit={onEmailRequest}>
+        <div className="grid gap-3">
+          <div className="grid gap-2">
+            <Label>Email</Label>
+            <Input
+              type="email"
+              placeholder="you@example.com"
+              required
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+            />
+          </div>
+          <Button disabled={!email.includes("@")} type="submit" className="w-full">
+            Email me a code
+          </Button>
+        </div>
+      </form>
+
+      <Divider label="or phone" />
+
+      <form onSubmit={onSmsRequest}>
+        <div className="grid gap-3">
+          <div className="grid gap-2">
+            <Label>Phone Number</Label>
+            <PhoneInput
+              placeholder="(408) 555-1234"
+              country="US"
+              className={cn(
+                "flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50",
+              )}
+              required
+              value={phoneNumber}
+              onChange={setPhoneNumber}
+            />
+          </div>
+          <Button
+            disabled={!isValidPhoneNumber(phoneNumber || "", "US")}
+            type="submit"
+            className="w-full"
+          >
+            Text me a code
+          </Button>
+        </div>
+      </form>
+    </>
+  );
+}
+
+function Divider({ label }: { label: string }) {
+  return (
     <div className="relative">
       <div className="absolute inset-0 flex items-center">
         <span className="w-full border-t" />
       </div>
       <div className="relative flex justify-center text-xs uppercase">
-        <span className="bg-background px-2 text-muted-foreground">
-          Or continue with
-        </span>
+        <span className="bg-background px-2 text-muted-foreground">{label}</span>
       </div>
     </div>
-
-    <form onSubmit={handleFormSubmit}>
-      <div className="grid gap-3">
-        <div className="grid gap-2">
-          <Label>Phone Number</Label>
-          <PhoneInput
-            placeholder="(408) 555-1234"
-            country="US"
-            className={cn(
-              "flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50",
-            )}
-            required
-            value={phoneNumber}
-            onChange={setPhoneNumber}
-          />
-        </div>
-        <Button
-          disabled={!isValidPhoneNumber(phoneNumber || "", "US")}
-          type="submit"
-          className="w-full"
-        >Continue</Button>
-        {captchaToken === "" ? <div className="block flex justify-center">
-          <Turnstile
-            options={{
-              theme: 'light',
-            }}
-            className="center"
-            siteKey={process.env.REACT_APP_CLOUDFLARE_SITE_KEY || ""}
-            onSuccess={(token) => {
-              setCaptchaToken(token)
-            }}
-          />
-        </div> : null}
-      </div>
-    </form >
-
-
-  </>)
+  );
 }
 
-function PhoneConfirmationDialog({
-  supabase,
+function SmsConfirmationPanel({
   phoneNumber,
-  close,
   setError,
   onSuccess,
 }: {
-  supabase: SupabaseClient,
-  phoneNumber: string,
-  close: () => void,
-  setError: React.Dispatch<React.SetStateAction<string>>,
-  onSuccess?: () => void
+  phoneNumber: string;
+  setError: React.Dispatch<React.SetStateAction<string>>;
+  onSuccess: () => void;
 }) {
-  const [confirmationCode, setConfirmationCode] = useState<string>("");
+  const { signIn } = useAuth();
+  const [code, setCode] = useState("");
 
   const onSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
-
-    const {
-      data,
-      error,
-    } = await supabase.auth.verifyOtp({
-      phone: phoneNumber,
-      token: confirmationCode,
-      type: "sms",
-    })
-    if (error) {
-      setError(error.message)
-    } else {
-      onSuccess && onSuccess()
-      close()
+    try {
+      await signIn.verifySmsOtp(phoneNumber, code);
+      onSuccess();
+    } catch (err: unknown) {
+      setError(err instanceof Error ? err.message : "Invalid code");
     }
-  }
+  };
 
-  return (<>
+  return (
     <form onSubmit={onSubmit}>
       <div className="grid gap-4">
-
         <div className="grid gap-2">
           <Label>SMS Confirmation Code</Label>
           <Input
             autoFocus
-            // placeholder="+1 (408) 555-1234"
-            // international
             required
             type="number"
-            value={confirmationCode}
+            value={code}
             onChange={(e) => {
-              setError("")
-              setConfirmationCode(e.target.value)
+              setError("");
+              setCode(e.target.value);
             }}
           />
         </div>
-        <Button
-          disabled={confirmationCode.toString().length !== 6}
-          type="submit"
-          className="w-full"
-        >Continue</Button>
+        <Button disabled={code.length !== 6} type="submit" className="w-full">
+          Continue
+        </Button>
       </div>
     </form>
-  </>)
+  );
+}
+
+function EmailConfirmationPanel({
+  email,
+  setError,
+  onSuccess,
+}: {
+  email: string;
+  setError: React.Dispatch<React.SetStateAction<string>>;
+  onSuccess: () => void;
+}) {
+  const { signIn } = useAuth();
+  const [code, setCode] = useState("");
+
+  const onSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    try {
+      await signIn.verifyEmailOtp(email, code);
+      onSuccess();
+    } catch (err: unknown) {
+      setError(err instanceof Error ? err.message : "Invalid code");
+    }
+  };
+
+  return (
+    <form onSubmit={onSubmit}>
+      <div className="grid gap-4">
+        <div className="grid gap-2">
+          <Label>Email Confirmation Code</Label>
+          <Input
+            autoFocus
+            required
+            type="number"
+            value={code}
+            onChange={(e) => {
+              setError("");
+              setCode(e.target.value);
+            }}
+          />
+        </div>
+        <Button disabled={code.length !== 6} type="submit" className="w-full">
+          Continue
+        </Button>
+      </div>
+    </form>
+  );
 }

--- a/frontend/src/common/Nav.tsx
+++ b/frontend/src/common/Nav.tsx
@@ -1,5 +1,5 @@
 import { GoogleAuthUser } from "../models";
-import { googleLogout, useGoogleLogin } from '@react-oauth/google';
+import { googleLogout } from '@react-oauth/google';
 import Navbar from 'react-bootstrap/Navbar';
 import Container from 'react-bootstrap/Container';
 import BootstrapNav from 'react-bootstrap/Nav';
@@ -21,7 +21,7 @@ export function Nav({ showLinks, setUser, loggedIn }: {
   const [showContactModal, setShowContactModal] = useState(false);
   const [showHelpModal, setShowHelpModal] = useState(false);
 
-  const { supabase, session } = useAuth();
+  const { signOut, session } = useAuth();
 
   const navigate = useNavigate()
 
@@ -40,7 +40,7 @@ export function Nav({ showLinks, setUser, loggedIn }: {
       <NavDropdown.Item onClick={() => {
         googleLogout();
         setUser(null);
-        supabase?.auth.signOut()
+        signOut();
         document.cookie = "googleAuthAccessToken=; expires=Thu, 01 Jan 1970 00:00:00 UTC; path=/; SameSite=Strict; Secure";
       }} className={styles.nav_link}>
         Logout

--- a/frontend/src/config.ts
+++ b/frontend/src/config.ts
@@ -1,0 +1,8 @@
+// Single source of truth for the API base URL. Keep this file dependency-free
+// so it can be imported from anywhere (including auth.tsx) without creating
+// circular module loads.
+export const endpoint = process.env.REACT_APP_API_PORT
+  ? `http://localhost:${process.env.REACT_APP_API_PORT}`
+  : process.env.NODE_ENV === "production"
+    ? "https://api.factor.trade"
+    : "http://localhost:3009";

--- a/frontend/src/pages/Backtest/Form.tsx
+++ b/frontend/src/pages/Backtest/Form.tsx
@@ -12,7 +12,7 @@ import { FaBookmark, FaRegBookmark } from "react-icons/fa";
 import { Tooltip as ReactTooltip } from 'react-tooltip';
 import { useGoogleLogin } from '@react-oauth/google';
 import modalsStyle from "common/Modals.module.css";
-import { Session } from '@supabase/supabase-js';
+import { AppSession as Session } from 'auth';
 import { useAuth } from 'auth';
 import LoginModal from 'common/AuthModals';
 

--- a/frontend/src/pages/Backtest/InvestInStrategy.tsx
+++ b/frontend/src/pages/Backtest/InvestInStrategy.tsx
@@ -12,7 +12,7 @@ import { updateBookmarked, getStrategies } from './Form';
 import { useGoogleLogin } from '@react-oauth/google';
 import modalStyles from "common/Modals.module.css";
 import factorSnapshotStyles from "./FactorSnapshot.module.css";
-import { Session } from '@supabase/supabase-js';
+import { AppSession as Session } from 'auth';
 import { useAuth } from 'auth';
 import LoginModal from 'common/AuthModals';
 

--- a/go.mod
+++ b/go.mod
@@ -53,6 +53,7 @@ require (
 	github.com/go-playground/universal-translator v0.18.1 // indirect
 	github.com/go-playground/validator/v10 v10.14.0 // indirect
 	github.com/goccy/go-json v0.10.2 // indirect
+	github.com/golang-jwt/jwt/v5 v5.3.1 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect

--- a/go.sum
+++ b/go.sum
@@ -171,6 +171,8 @@ github.com/gofrs/uuid v3.2.0+incompatible/go.mod h1:b2aQJv3Z4Fp6yNu3cdSllBxTCLRx
 github.com/gofrs/uuid v4.0.0+incompatible/go.mod h1:b2aQJv3Z4Fp6yNu3cdSllBxTCLRxnplIgP/c0N/04lM=
 github.com/golang-jwt/jwt v3.2.2+incompatible h1:IfV12K8xAKAnZqdXVzCZ+TOjboZ2keLg81eXfW3O+oY=
 github.com/golang-jwt/jwt v3.2.2+incompatible/go.mod h1:8pz2t5EyA70fFQQSrl6XZXzqecmYZeUEB8OUGHkxJ+I=
+github.com/golang-jwt/jwt/v5 v5.3.1 h1:kYf81DTWFe7t+1VvL7eS+jKFVWaUnK9cB1qbwn63YCY=
+github.com/golang-jwt/jwt/v5 v5.3.1/go.mod h1:fxCRLWMO43lRc8nhHWY6LGqRcf+1gQWArsqaEUEa5bE=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
 github.com/golang/groupcache v0.0.0-20190702054246-869f871628b6/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/golang/groupcache v0.0.0-20191227052852-215e87163ea7/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=

--- a/internal/db/models/postgres/public/enum/user_account_provider_type.go
+++ b/internal/db/models/postgres/public/enum/user_account_provider_type.go
@@ -4,17 +4,24 @@
 // WARNING: Changes to this file may cause incorrect behavior
 // and will be lost if the code is regenerated
 //
+// HAND-EDITED: BetterAuth was added manually alongside migration 000052.
+// If you re-run `make db-models`, re-add the BetterAuth field + enum value
+// to keep auth code that references model.UserAccountProviderType_BetterAuth
+// compiling. Same edit applies to ../model/user_account_provider_type.go.
+//
 
 package enum
 
 import "github.com/go-jet/jet/v2/postgres"
 
 var UserAccountProviderType = &struct {
-	Supabase postgres.StringExpression
-	Google   postgres.StringExpression
-	Manual   postgres.StringExpression
+	Supabase   postgres.StringExpression
+	Google     postgres.StringExpression
+	Manual     postgres.StringExpression
+	BetterAuth postgres.StringExpression
 }{
-	Supabase: postgres.NewEnumValue("SUPABASE"),
-	Google:   postgres.NewEnumValue("GOOGLE"),
-	Manual:   postgres.NewEnumValue("MANUAL"),
+	Supabase:   postgres.NewEnumValue("SUPABASE"),
+	Google:     postgres.NewEnumValue("GOOGLE"),
+	Manual:     postgres.NewEnumValue("MANUAL"),
+	BetterAuth: postgres.NewEnumValue("BETTER_AUTH"),
 }

--- a/internal/db/models/postgres/public/model/user_account_provider_type.go
+++ b/internal/db/models/postgres/public/model/user_account_provider_type.go
@@ -12,9 +12,10 @@ import "errors"
 type UserAccountProviderType string
 
 const (
-	UserAccountProviderType_Supabase UserAccountProviderType = "SUPABASE"
-	UserAccountProviderType_Google   UserAccountProviderType = "GOOGLE"
-	UserAccountProviderType_Manual   UserAccountProviderType = "MANUAL"
+	UserAccountProviderType_Supabase   UserAccountProviderType = "SUPABASE"
+	UserAccountProviderType_Google     UserAccountProviderType = "GOOGLE"
+	UserAccountProviderType_Manual     UserAccountProviderType = "MANUAL"
+	UserAccountProviderType_BetterAuth UserAccountProviderType = "BETTER_AUTH"
 )
 
 func (e *UserAccountProviderType) Scan(value interface{}) error {
@@ -35,6 +36,8 @@ func (e *UserAccountProviderType) Scan(value interface{}) error {
 		*e = UserAccountProviderType_Google
 	case "MANUAL":
 		*e = UserAccountProviderType_Manual
+	case "BETTER_AUTH":
+		*e = UserAccountProviderType_BetterAuth
 	default:
 		return errors.New("jet: Invalid scan value '" + enumValue + "' for UserAccountProviderType enum")
 	}

--- a/internal/db/models/postgres/public/model/user_account_provider_type.go
+++ b/internal/db/models/postgres/public/model/user_account_provider_type.go
@@ -4,6 +4,11 @@
 // WARNING: Changes to this file may cause incorrect behavior
 // and will be lost if the code is regenerated
 //
+// HAND-EDITED: BetterAuth was added manually alongside migration 000052.
+// If you re-run `make db-models`, re-add the constant and the Scan case to
+// keep auth code that references UserAccountProviderType_BetterAuth
+// compiling. Same edit applies to ../enum/user_account_provider_type.go.
+//
 
 package model
 

--- a/migrations/000052_user_account_better_auth.up.sql
+++ b/migrations/000052_user_account_better_auth.up.sql
@@ -1,0 +1,3 @@
+-- Add BETTER_AUTH to the user_account_provider_type enum so the Go API
+-- can persist users created via the embedded Better Auth service.
+ALTER TYPE user_account_provider_type ADD VALUE IF NOT EXISTS 'BETTER_AUTH';

--- a/plans/fly-deployment.md
+++ b/plans/fly-deployment.md
@@ -142,40 +142,34 @@ The Go process binds the public port (3009) and reverse-proxies
 `/api/auth/*` to `127.0.0.1:3001`. The sidecar code lives in
 [auth-service/](../auth-service/).
 
-### Additional secrets
+### Additional secrets (5–6 values; everything else is in fly.toml)
 
-Run alongside the existing 13 secrets above. All names are case-sensitive.
-Use a dedicated secret per env so the auth sidecar config validation stops
-the deploy if anything is missing.
+Non-secret config (`APP_BASE_URL`, `TRUSTED_ORIGINS`, feature flags,
+`EMAIL_PROVIDER`, etc.) lives in [fly.toml](../fly.toml)'s `[env]` block —
+source-controlled and diffable.  Only the actual sensitive values go through
+`flyctl secrets set`. The names match the camelCase pattern already used by
+the Go side.
 
 ```sh
 flyctl secrets set \
-  APP_BASE_URL='https://factorbacktest.fly.dev' \
-  BETTER_AUTH_SECRET="$(openssl rand -hex 32)" \
-  DATABASE_URL='postgres://<db-user>:<db-password>@<rds-host>:5432/<dbname>?sslmode=require' \
-  AUTH_DB_SCHEMA='auth' \
-  TRUSTED_ORIGINS='https://factorbacktest.fly.dev,https://factor.trade,https://www.factor.trade' \
-  FEATURE_GOOGLE='true' \
-  FEATURE_EMAIL_OTP='true' \
-  FEATURE_SMS_OTP='true' \
-  GOOGLE_CLIENT_ID='<google-client-id>' \
-  GOOGLE_CLIENT_SECRET='<google-client-secret>' \
-  EMAIL_PROVIDER='resend' \
-  EMAIL_FROM='Factor.trade <noreply@factor.trade>' \
-  RESEND_API_KEY='<resend-api-key>' \
-  SMS_PROVIDER='twilio' \
-  SMS_FROM='+15551234567' \
-  TWILIO_ACCOUNT_SID='<twilio-sid>' \
-  TWILIO_AUTH_TOKEN='<twilio-auth-token>' \
-  TWILIO_MESSAGING_SERVICE_SID='<optional-msg-service-sid>' \
-  APP_USER_SYNC_ENABLED='false'
+  betterAuthSecret="$(openssl rand -hex 32)" \
+  googleClientId='<google-client-id>' \
+  googleClientSecret='<google-client-secret>' \
+  resendApiKey='<resend-api-key>' \
+  twilioAccountSid='<twilio-sid>' \
+  twilioAuthToken='<twilio-auth-token>'
 ```
 
-`APP_USER_SYNC_ENABLED=false` is intentional for *this* app: we already have
-`user_account` as the canonical app user table and `getGoogleAuthMiddleware`
-upserts into it on every authenticated request. The generic
-`public.app_user_profile` bridge table created by the auth-service bootstrap
-is for new projects that don't have an existing user table.
+DB connection info (`host`, `password`, etc.) is reused from the secrets
+already set for the Go API — the auth-service builds its own connection
+string from them. There is no separate `DATABASE_URL`.
+
+`APP_USER_SYNC_ENABLED` is set to `false` in `fly.toml` because this app
+already has `user_account` as the canonical app user table and
+`getGoogleAuthMiddleware` upserts into it on every authenticated request.
+The generic `public.app_user_profile` bridge table created by the
+auth-service bootstrap is for new projects that don't have an existing
+user table.
 
 ### Google OAuth redirect URI
 
@@ -212,13 +206,17 @@ Supabase sessions working. Sequence:
    - SMS: enter phone, verify Twilio delivers a code, finish sign-in.
 5. Verify `auth.user`, `auth.session`, etc. are populated and `user_account`
    gets `Provider='BETTER_AUTH'` rows for new sign-ins.
-6. Once confident, remove the Supabase secrets and code:
-   ```sh
-   flyctl secrets unset jwt   # the Supabase HS256 secret
-   ```
-   Then drop `parseSupabaseJWT` and the Supabase fallback from
-   [api/api.go](../api/api.go) and remove `@supabase/supabase-js` from
-   [frontend/package.json](../frontend/package.json).
+6. Once confident, remove Supabase entirely:
+   - `flyctl secrets unset jwt` (the Supabase HS256 secret).
+   - Drop `parseSupabaseJWT` and the Supabase fallback branch from
+     [api/api.go](../api/api.go).
+   - Drop the `Jwt` field from `Secrets` in
+     [internal/util/util.go](../internal/util/util.go) (and the
+     `JwtDecodeToken` plumbing in [cmd/util.go](../cmd/util.go) /
+     [api/api.go](../api/api.go)).
+   - Remove `@supabase/supabase-js` from
+     [frontend/package.json](../frontend/package.json) and any leftover
+     references.
 
 ### Cost note
 

--- a/plans/fly-deployment.md
+++ b/plans/fly-deployment.md
@@ -133,3 +133,94 @@ When you want to send real traffic to Fly:
 `min_machines_running = 0` means the machine sleeps when idle and wakes on
 the next request (a few-hundred-ms cold start). Expect a few dollars a
 month. Bump to `performance-2x` if backtests feel CPU-bound.
+
+## Embedded Better Auth sidecar
+
+The Fly machine now runs the Go API and a Node Better Auth sidecar in the
+same container ([Dockerfile.fly](../Dockerfile.fly), [scripts/start.sh](../scripts/start.sh)).
+The Go process binds the public port (3009) and reverse-proxies
+`/api/auth/*` to `127.0.0.1:3001`. The sidecar code lives in
+[auth-service/](../auth-service/).
+
+### Additional secrets
+
+Run alongside the existing 13 secrets above. All names are case-sensitive.
+Use a dedicated secret per env so the auth sidecar config validation stops
+the deploy if anything is missing.
+
+```sh
+flyctl secrets set \
+  APP_BASE_URL='https://factorbacktest.fly.dev' \
+  BETTER_AUTH_SECRET="$(openssl rand -hex 32)" \
+  DATABASE_URL='postgres://<db-user>:<db-password>@<rds-host>:5432/<dbname>?sslmode=require' \
+  AUTH_DB_SCHEMA='auth' \
+  TRUSTED_ORIGINS='https://factorbacktest.fly.dev,https://factor.trade,https://www.factor.trade' \
+  FEATURE_GOOGLE='true' \
+  FEATURE_EMAIL_OTP='true' \
+  FEATURE_SMS_OTP='true' \
+  GOOGLE_CLIENT_ID='<google-client-id>' \
+  GOOGLE_CLIENT_SECRET='<google-client-secret>' \
+  EMAIL_PROVIDER='resend' \
+  EMAIL_FROM='Factor.trade <noreply@factor.trade>' \
+  RESEND_API_KEY='<resend-api-key>' \
+  SMS_PROVIDER='twilio' \
+  SMS_FROM='+15551234567' \
+  TWILIO_ACCOUNT_SID='<twilio-sid>' \
+  TWILIO_AUTH_TOKEN='<twilio-auth-token>' \
+  TWILIO_MESSAGING_SERVICE_SID='<optional-msg-service-sid>' \
+  APP_USER_SYNC_ENABLED='false'
+```
+
+`APP_USER_SYNC_ENABLED=false` is intentional for *this* app: we already have
+`user_account` as the canonical app user table and `getGoogleAuthMiddleware`
+upserts into it on every authenticated request. The generic
+`public.app_user_profile` bridge table created by the auth-service bootstrap
+is for new projects that don't have an existing user table.
+
+### Google OAuth redirect URI
+
+Add **`https://factorbacktest.fly.dev/api/auth/callback/google`** to the
+authorized redirect URIs in the Google Cloud Console (Credentials → OAuth
+2.0 Client ID). For local dev, also add `http://localhost:3009/api/auth/callback/google`.
+
+### Database prerequisite
+
+The auth-service runs `CREATE SCHEMA IF NOT EXISTS auth` and
+`npx @better-auth/cli migrate` on every container start. The database user
+must have permission to create schemas; if you use a least-privilege user,
+grant once:
+
+```sql
+GRANT CREATE ON DATABASE <dbname> TO <db-user>;
+GRANT ALL PRIVILEGES ON SCHEMA auth TO <db-user>;
+ALTER DEFAULT PRIVILEGES IN SCHEMA auth GRANT ALL ON TABLES TO <db-user>;
+```
+
+### Cutover from Supabase
+
+The Go middleware in [api/api.go](../api/api.go) tries Better Auth JWTs
+first and falls back to Supabase, so deploying this image leaves existing
+Supabase sessions working. Sequence:
+
+1. Set the new secrets above (does not affect the live Supabase path).
+2. Update Google's OAuth redirect URIs.
+3. `flyctl deploy --remote-only` (or push to `master`).
+4. Smoke test all three flows on the deployed URL:
+   - Google: click "Continue with Google", verify a session cookie comes back.
+   - Email: enter address, watch `flyctl logs` for the OTP (Resend provider
+     sends a real email; the console provider would log to stdout).
+   - SMS: enter phone, verify Twilio delivers a code, finish sign-in.
+5. Verify `auth.user`, `auth.session`, etc. are populated and `user_account`
+   gets `Provider='BETTER_AUTH'` rows for new sign-ins.
+6. Once confident, remove the Supabase secrets and code:
+   ```sh
+   flyctl secrets unset jwt   # the Supabase HS256 secret
+   ```
+   Then drop `parseSupabaseJWT` and the Supabase fallback from
+   [api/api.go](../api/api.go) and remove `@supabase/supabase-js` from
+   [frontend/package.json](../frontend/package.json).
+
+### Cost note
+
+The Node sidecar idles at <50MB RSS and shares the same `shared-cpu-2x` /
+1GB machine. No size bump needed unless traffic patterns change.

--- a/plans/fly-deployment.md
+++ b/plans/fly-deployment.md
@@ -155,10 +155,20 @@ flyctl secrets set \
   betterAuthSecret="$(openssl rand -hex 32)" \
   googleClientId='<google-client-id>' \
   googleClientSecret='<google-client-secret>' \
-  resendApiKey='<resend-api-key>' \
-  twilioAccountSid='<twilio-sid>' \
-  twilioAuthToken='<twilio-auth-token>'
+  twilioAccountSid='<twilio-verify-account-sid>' \
+  twilioAuthToken='<twilio-verify-auth-token>' \
+  twilioVerifyServiceSid='<twilio-verify-service-sid>'
 ```
+
+SMS OTP runs through **Twilio Verify** (Twilio generates, sends, and
+validates the code; we never store SMS codes). The auth-service
+auto-detects Twilio Verify mode from the presence of
+`twilioVerifyServiceSid` and wires `verifyOTP` accordingly.
+
+Email OTP is **disabled** for the initial cutover (`FEATURE_EMAIL_OTP=false`
+in `fly.toml`) to preserve parity with the previous Supabase setup. To
+enable later: wire an email provider (Resend or SES), set its API key, and
+flip the flag.
 
 DB connection info (`host`, `password`, etc.) is reused from the secrets
 already set for the Go API — the auth-service builds its own connection

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -14,7 +14,7 @@ echo "[start.sh] running auth-service bootstrap"
 ( cd /app/auth-service && node dist/scripts/bootstrap.js )
 
 echo "[start.sh] running better-auth migrations"
-( cd /app/auth-service && npx --yes @better-auth/cli@latest migrate --yes --config ./dist/auth.js )
+( cd /app/auth-service && npx --yes @better-auth/cli@1.6.9 migrate --yes --config ./dist/auth.js )
 
 # ---------------------------------------------------------------------------
 # Start the Node auth-service. Binds to 127.0.0.1:3001 (set in env).
@@ -27,9 +27,11 @@ NODE_PID=$!
 # upstream from the first request. Time-bounded so a broken sidecar still
 # fails the container quickly instead of hanging forever.
 echo "[start.sh] waiting for auth-service health"
+HEALTHY=0
 for i in $(seq 1 30); do
   if curl -fsS http://127.0.0.1:3001/api/auth/ok >/dev/null 2>&1; then
     echo "[start.sh] auth-service is up"
+    HEALTHY=1
     break
   fi
   if ! kill -0 "$NODE_PID" 2>/dev/null; then
@@ -38,6 +40,15 @@ for i in $(seq 1 30); do
   fi
   sleep 1
 done
+
+if [ "$HEALTHY" != "1" ]; then
+  # Don't start Go if the sidecar isn't responding — the proxy would
+  # immediately 502 on every /api/auth/* call and Fly's health check
+  # would still pass, masking the failure indefinitely.
+  echo "[start.sh] auth-service did not become healthy in 30s; aborting"
+  kill -TERM "$NODE_PID" 2>/dev/null || true
+  exit 1
+fi
 
 # ---------------------------------------------------------------------------
 # Start the Go API in the foreground (so its exit triggers container exit).

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+# Supervisor for the Fly.io image. Runs the Node auth-service and the Go API
+# in the same container. tini (PID 1) reaps zombies and forwards signals to
+# this script; we forward to both children on shutdown.
+set -euo pipefail
+
+cd /app
+
+# ---------------------------------------------------------------------------
+# Bootstrap auth schema + apply Better Auth migrations.
+# Both are idempotent so it's safe to do this on every container start.
+# ---------------------------------------------------------------------------
+echo "[start.sh] running auth-service bootstrap"
+( cd /app/auth-service && node dist/scripts/bootstrap.js )
+
+echo "[start.sh] running better-auth migrations"
+( cd /app/auth-service && npx --yes @better-auth/cli@latest migrate --yes --config ./dist/auth.js )
+
+# ---------------------------------------------------------------------------
+# Start the Node auth-service. Binds to 127.0.0.1:3001 (set in env).
+# ---------------------------------------------------------------------------
+echo "[start.sh] launching auth-service"
+( cd /app/auth-service && node dist/src/server.js ) &
+NODE_PID=$!
+
+# Wait for /api/auth/ok before starting Go so the reverse proxy sees a healthy
+# upstream from the first request. Time-bounded so a broken sidecar still
+# fails the container quickly instead of hanging forever.
+echo "[start.sh] waiting for auth-service health"
+for i in $(seq 1 30); do
+  if curl -fsS http://127.0.0.1:3001/api/auth/ok >/dev/null 2>&1; then
+    echo "[start.sh] auth-service is up"
+    break
+  fi
+  if ! kill -0 "$NODE_PID" 2>/dev/null; then
+    echo "[start.sh] auth-service exited before becoming healthy"
+    exit 1
+  fi
+  sleep 1
+done
+
+# ---------------------------------------------------------------------------
+# Start the Go API in the foreground (so its exit triggers container exit).
+# ---------------------------------------------------------------------------
+echo "[start.sh] launching Go API"
+/app/api &
+GO_PID=$!
+
+terminate() {
+  echo "[start.sh] received signal, shutting down children"
+  kill -TERM "$GO_PID" 2>/dev/null || true
+  kill -TERM "$NODE_PID" 2>/dev/null || true
+  wait "$GO_PID" 2>/dev/null || true
+  wait "$NODE_PID" 2>/dev/null || true
+  exit 0
+}
+trap terminate TERM INT
+
+# If either process dies, exit so Fly restarts the machine.
+wait -n "$GO_PID" "$NODE_PID"
+EXIT_CODE=$?
+echo "[start.sh] a child process exited (code=$EXIT_CODE), shutting down"
+kill -TERM "$GO_PID" 2>/dev/null || true
+kill -TERM "$NODE_PID" 2>/dev/null || true
+wait "$GO_PID" 2>/dev/null || true
+wait "$NODE_PID" 2>/dev/null || true
+exit "$EXIT_CODE"

--- a/secrets-test.json
+++ b/secrets-test.json
@@ -25,6 +25,7 @@
     "googleClientSecret": "",
     "resendApiKey": "",
     "twilioAccountSid": "",
-    "twilioAuthToken": ""
+    "twilioAuthToken": "",
+    "twilioVerifyServiceSid": ""
   }
 }

--- a/secrets-test.json
+++ b/secrets-test.json
@@ -18,5 +18,13 @@
   "ses": {
     "region": "test",
     "fromEmail": "test"
+  },
+  "auth": {
+    "betterAuthSecret": "test-test-test-test-test-test-test-test",
+    "googleClientId": "",
+    "googleClientSecret": "",
+    "resendApiKey": "",
+    "twilioAccountSid": "",
+    "twilioAuthToken": ""
   }
 }


### PR DESCRIPTION
## Summary

Replaces Supabase auth with a self-contained Node Better Auth service that runs alongside the Go API in the same Fly.io machine, sharing the existing Postgres in a dedicated `auth` schema. Supports Google, Email OTP, and SMS OTP. No passwords. Designed to be drop-in reusable across side projects.

- One Fly machine, one Postgres. Tini-supervised container runs Go on :3009 (public) and Node on 127.0.0.1:3001 (private). Go reverse-proxies `/api/auth/*` to Node; everything else hits Go.
- Better Auth owns its own `auth` schema via `?options=-c search_path=auth`. `npx @better-auth/cli migrate` runs at container start and only touches that schema.
- Token validation is JWKS-based (EdDSA / Ed25519). The Go middleware tries Better Auth JWTs first and falls back to Supabase, so this PR is **safe to deploy with no user-facing impact** — existing Supabase sessions keep working until you remove the fallback.
- The `auth-service/` folder is the reusable artifact: copy it into another project, change env vars, done.

Worth flagging because it's a chunky diff (~4k lines, mostly new files in `auth-service/` + `frontend/package-lock.json`):

- `auth-service/` — the new Node service (~600 LOC of actual TS).
- `api/better_auth.go` + `api/auth_proxy.go` — Go-side JWKS validator and reverse proxy.
- `api/api.go` — middleware now tries Better Auth -> Supabase -> Google in that order. CORS gained `AllowCredentials: true` for cookie-based sessions.
- `frontend/src/auth.tsx` + `AuthModals.tsx` — Better Auth React client; `useAuth()` keeps the same shape (`session.access_token`, etc.) so the 13 callsites doing `Bearer \${session.access_token}` did not change.
- `Dockerfile.fly` + `scripts/start.sh` — multi-stage build (Go + Node), supervisor that bootstraps schema, runs migrate, waits for sidecar healthcheck, then starts Go.
- `migrations/000052_*.sql` — adds `BETTER_AUTH` to the `user_account_provider_type` enum.
- `plans/fly-deployment.md` — new section with the exact `flyctl secrets set` block and 6-step cutover checklist.

## What's already verified

- Go: \`go build ./... && go test ./api/...\` clean (3 new EdDSA/JWKS tests).
- Auth-service: \`tsc --noEmit\` + \`npm run build\` clean.
- End-to-end against docker-compose Postgres: Email OTP send -> verify -> session cookie -> JWT issuance; SMS OTP same flow; all 5 Better Auth tables land in \`auth\` schema (zero leak into \`public\`); cross-schema sync hook fires.
- Frontend: \`tsc --noEmit\` + \`react-scripts build\` clean (TypeScript bumped 4.9 -> 5 to parse Better Auth's type defs).
- Multi-stage Docker image builds; ran the full image locally and confirmed \`curl localhost:13009/api/auth/ok\` round-trips through Go's public port to the Node sidecar.

## Test plan

Tier 1 — re-run the automated checks:

- [ ] \`go build ./... && go test ./api/...\`
- [ ] \`cd auth-service && npx tsc --noEmit && npm run build\`
- [ ] \`cd frontend && npx tsc --noEmit && GENERATE_SOURCEMAP=false npm run build\`
- [ ] \`docker build -f Dockerfile.fly -t fb-fly:test .\`

Tier 2 — local browser smoke (10 min, recommended):

- [ ] \`docker compose up -d postgres\`
- [ ] \`cd auth-service && npm run dev\` (uses console providers; OTPs print to stdout)
- [ ] \`go run ./cmd/api\`
- [ ] \`cd frontend && npm start\`
- [ ] In browser at \`http://localhost:3000\`: email-OTP login (grab code from auth-service terminal) -> session active -> trigger an authenticated action (e.g. bookmark a strategy) and confirm 200.
- [ ] Same with phone-OTP.

Tier 3 — production deploy (no big-bang because Supabase fallback is still in place):

- [ ] Apply migration \`000052_user_account_better_auth.up.sql\` on prod DB.
- [ ] Add \`https://factorbacktest.fly.dev/api/auth/callback/google\` to Google Cloud OAuth redirect URIs.
- [ ] Run the \`flyctl secrets set ...\` block from \`plans/fly-deployment.md\`.
- [ ] Deploy. Existing Supabase sessions keep working untouched.
- [ ] Smoke test all three flows on the live URL with a fresh account.
- [ ] Watch \`flyctl logs\` for ~24h.

Tier 4 — remove Supabase (separate PR after Tier 3 settles):

- [ ] \`flyctl secrets unset jwt\`
- [ ] Remove the Supabase fallback branch in \`api/api.go\`, drop \`parseSupabaseJWT\`, \`npm uninstall @supabase/supabase-js\`.

## Risks / known gotchas

- SMS sender is BYO (Twilio configured in `auth-service/src/providers/sms-twilio.ts`); console provider is for dev only.
- `search_path` may not stick under PgBouncer transaction-mode pooling. Fly Postgres uses session pooling, so we're fine, but called out in `plans/fly-deployment.md`.
- Phone plugin also exposes a password-based `/sign-in/phone-number` endpoint we don't want; it's not surfaced from the React client and `emailAndPassword` is disabled, so it stays unreachable.

Made with [Cursor](https://cursor.com)