### PR TITLE
ci(frontend): deploy to S3 + invalidate CloudFront on master merge

### DIFF
--- a/.github/workflows/deploy-frontend.yml
+++ b/.github/workflows/deploy-frontend.yml
@@ -1,0 +1,64 @@
+name: Deploy Frontend
+
+on:
+  push:
+    branches: ["master"]
+    paths:
+      - 'frontend/**'
+      - '.github/workflows/deploy-frontend.yml'
+
+permissions:
+  id-token: write
+  contents: read
+
+concurrency:
+  group: deploy-frontend-main
+  cancel-in-progress: false
+
+env:
+  AWS_REGION: us-east-1
+  AWS_ACCOUNT_ID: "326651360928"
+
+jobs:
+  deploy-frontend:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Install dependencies
+        working-directory: frontend
+        run: npm ci
+
+      - name: Build
+        working-directory: frontend
+        run: npm run build
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-region: ${{ env.AWS_REGION }}
+          role-to-assume: arn:aws:iam::${{ env.AWS_ACCOUNT_ID }}:role/factorbacktest-github-deploy
+          role-session-name: factorbacktest-github-deploy
+
+      - name: Verify AWS identity
+        run: aws sts get-caller-identity
+
+      - name: Sync to S3
+        run: |
+          aws s3 sync ./frontend/build s3://factorbacktest.net --delete
+          aws s3 sync ./frontend/build s3://www.factorbacktest.net --delete
+          aws s3 sync ./frontend/build s3://factor.trade --delete
+          aws s3 sync ./frontend/build s3://www.factor.trade --delete
+
+      - name: Invalidate CloudFront
+        run: |
+          aws cloudfront create-invalidation --distribution-id E2LDUUB6BBDSV8 --paths "/*" --output text
+          aws cloudfront create-invalidation --distribution-id E28M2984LB2P97 --paths "/*" --output text


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/deploy-frontend.yml` which builds the React app and syncs to all four hosting buckets, then invalidates both CloudFront distributions on push to `master`.
- Reuses the existing `factorbacktest-github-deploy` OIDC role (perms updated separately to cover S3 sync + CloudFront invalidation).
- Path-filtered to `frontend/**` and the workflow file itself, so unrelated backend pushes don't trigger it.

## Test plan
- [ ] Merge and watch the Deploy Frontend run succeed
- [ ] Confirm a small frontend change ships to factorbacktest.net / factor.trade after CloudFront invalidation

Made with [Cursor](https://cursor.com)