### PR TITLE
ci(frontend): build with CI=false to match local deploy

### DIFF
--- a/.github/workflows/deploy-frontend.yml
+++ b/.github/workflows/deploy-frontend.yml
@@ -39,6 +39,8 @@ jobs:
 
       - name: Build
         working-directory: frontend
+        env:
+          CI: false
         run: npm run build
 
       - name: Configure AWS credentials


### PR DESCRIPTION
## Summary
- Sets `CI=false` for the `npm run build` step so react-scripts doesn't promote the repo's existing eslint warnings into compile errors.
- Mirrors the behavior of `make deploy-fe` run locally, which is what's been shipping today.

Follow-up to #109. Cleaning up the underlying warnings is worth doing separately and not blocking on for the deploy wiring.

## Test plan
- [ ] Merge and confirm the Deploy Frontend run goes green end-to-end (build, S3 sync, CloudFront invalidation)

Made with [Cursor](https://cursor.com)