### PR TITLE
fix(auth-service): unblock prod after pg TLS regression and npx-on-boot crash loop

### DIFF
--- a/auth-service/auth.ts
+++ b/auth-service/auth.ts
@@ -8,6 +8,7 @@ const config = loadConfig();
 
 export const pool = new Pool({
   connectionString: config.database.url,
+  ssl: config.database.ssl,
   max: 10,
 });
 

--- a/auth-service/package.json
+++ b/auth-service/package.json
@@ -12,8 +12,8 @@
     "build": "tsc -p tsconfig.json",
     "start": "node dist/server.js",
     "bootstrap": "tsx scripts/bootstrap.ts",
-    "migrate": "npx --yes @better-auth/cli@1.6.9 migrate --yes --config ./auth.ts",
-    "generate": "npx --yes @better-auth/cli@1.6.9 generate --yes --config ./auth.ts"
+    "migrate": "npx --yes @better-auth/cli@latest migrate --yes --config ./auth.ts",
+    "generate": "npx --yes @better-auth/cli@latest generate --yes --config ./auth.ts"
   },
   "dependencies": {
     "@hono/node-server": "^1.13.7",

--- a/auth-service/scripts/bootstrap.ts
+++ b/auth-service/scripts/bootstrap.ts
@@ -33,7 +33,10 @@ const main = async () => {
   }
   const sql = BOOTSTRAP_SQL.replace("__SCHEMA__", schema);
 
-  const client = new Client({ connectionString: adminUrl.toString() });
+  const client = new Client({
+    connectionString: adminUrl.toString(),
+    ssl: config.database.ssl,
+  });
   await client.connect();
   try {
     await client.query(sql);

--- a/auth-service/src/config.ts
+++ b/auth-service/src/config.ts
@@ -1,5 +1,5 @@
 import { z } from "zod";
-import { buildDatabaseUrl, loadSecrets } from "./secrets.js";
+import { buildDatabaseUrl, buildPoolSslOption, loadSecrets } from "./secrets.js";
 
 // Non-secret configuration. All values default to something sensible for
 // local dev so a fresh checkout with a populated `secrets.json` "just works".
@@ -40,6 +40,7 @@ export interface AuthConfig {
   database: {
     url: string;
     schema: string;
+    ssl: { rejectUnauthorized: false } | false;
   };
   features: {
     google: boolean;
@@ -122,6 +123,7 @@ export const loadConfig = (): AuthConfig => {
     database: {
       url: buildDatabaseUrl(secrets.db, env.AUTH_DB_SCHEMA),
       schema: env.AUTH_DB_SCHEMA,
+      ssl: buildPoolSslOption(secrets.db),
     },
     features,
     google,

--- a/auth-service/src/secrets.ts
+++ b/auth-service/src/secrets.ts
@@ -200,6 +200,14 @@ export const loadSecrets = (cwd = process.cwd()): ResolvedSecrets => {
 
 // Builds a Postgres connection string with `?options=-c search_path=<schema>`
 // applied so Better Auth lands tables in the correct schema.
+//
+// SSL policy is set on the pg `Client` / `Pool` constructor via
+// `buildPoolSslOption` (which overrides anything parsed from the URL), so
+// the only `sslmode` we encode here is `disable` for envs that opt out of
+// TLS entirely (i.e. local dev against Docker Postgres). Encoding
+// `sslmode=require` in the URL would also work in prod but produces a
+// migration warning from pg-connection-string@2.12+, so we keep the policy
+// in one place — the Pool config — instead.
 export const buildDatabaseUrl = (db: DbSecrets, schema: string): string => {
   // Defense in depth: even though zod typechecks `schema` as a string, the
   // value is interpolated directly into the connection string's `options`
@@ -214,11 +222,25 @@ export const buildDatabaseUrl = (db: DbSecrets, schema: string): string => {
   u.hostname = db.host;
   u.port = db.port;
   u.pathname = `/${db.database}`;
-  if (db.enableSsl !== false) {
-    u.searchParams.set("sslmode", "require");
-  } else {
+  if (db.enableSsl === false) {
     u.searchParams.set("sslmode", "disable");
   }
   u.searchParams.set("options", `-c search_path=${schema}`);
   return u.toString();
+};
+
+// Returns the `ssl` option to pass to pg `Client` / `Pool`.
+//
+// - `enableSsl !== false` (prod default): use TLS but do NOT verify the
+//   certificate chain. This matches the Go side, which connects with
+//   libpq's `sslmode=prefer` semantics (encrypt, don't verify). Strict
+//   verification would fail with `CERT_HAS_EXPIRED` whenever the upstream
+//   Postgres provider's chain doesn't validate against Node's bundled CAs,
+//   which has happened in prod.
+// - `enableSsl === false` (local Docker Postgres): no TLS at all.
+export const buildPoolSslOption = (
+  db: DbSecrets,
+): { rejectUnauthorized: false } | false => {
+  if (db.enableSsl === false) return false;
+  return { rejectUnauthorized: false };
 };

--- a/fly.toml
+++ b/fly.toml
@@ -28,7 +28,10 @@ primary_region = "iad"
   force_https = true
   auto_stop_machines = "stop"
   auto_start_machines = true
-  min_machines_running = 0
+  # Keep one machine warm so users don't eat the ~30s cold-start hit (Node
+  # auth-service + Go API + Postgres TLS handshake) on the first request
+  # after a quiet period.
+  min_machines_running = 1
 
   [[http_service.checks]]
     method = "get"

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -13,8 +13,14 @@ cd /app
 echo "[start.sh] running auth-service bootstrap"
 ( cd /app/auth-service && node dist/scripts/bootstrap.js )
 
-echo "[start.sh] running better-auth migrations"
-( cd /app/auth-service && npx --yes @better-auth/cli@1.6.9 migrate --yes --config ./dist/auth.js )
+# Better Auth migrations are deliberately NOT run at container boot. The CLI
+# is shipped as a separate `@better-auth/cli` package whose version line
+# doesn't track the runtime library, and `npx --yes @better-auth/cli@latest`
+# pulls ~150 packages from npm on every cold start (~2.5 min). The auth
+# schema itself is created by the bootstrap step above (idempotent), and any
+# additive migrations should be run from a developer machine via
+# `npm run migrate` in `auth-service/` before the corresponding deploy.
+echo "[start.sh] skipping runtime better-auth migrate (run \`npm run migrate\` locally before deploys that change auth schema)"
 
 # ---------------------------------------------------------------------------
 # Start the Node auth-service. Binds to 127.0.0.1:3001 (set in env).


### PR DESCRIPTION
## Summary

The prod hotfixes from earlier tonight, already deployed. Splitting into its own PR so the custom Go auth PR (#112) reviews clean.

Three independent issues caused `api.factor.trade` to return 502s on auth endpoints around 8pm ET, all in the Node Better Auth sidecar:

1. **`pg-connection-string@2.12` reinterprets `sslmode=require` as `verify-full`**, which Node then rejects against the upstream Postgres provider with `CERT_HAS_EXPIRED`. Go connects with libpq's permissive default, so TLS-without-strict-verification matches existing semantics. Pass `ssl: { rejectUnauthorized: false }` explicitly to the pg `Pool` / `Client` (overrides whatever's parsed from the URL) and stop encoding `sslmode=require` in the connection string.
2. **`start.sh` runs `npx --yes @better-auth/cli@1.6.9 migrate` on every boot**, but that version no longer exists on npm and the CLI's version line doesn't track the runtime library's anyway. Drop the runtime migrate step entirely — the auth schema is created idempotently by the bootstrap step above, and any actual schema changes should be applied by `npm run migrate` from a developer machine before deploying.
3. **`min_machines_running = 0`** meant every quiet period saddled the next user with the full ~30s cold start. Bumped to 1.

## Test plan

- [x] Already deployed and verified live: `/api/auth/get-session` returns `200`, `/publishedStrategies` returns `200` in <500ms.
- [x] `go build ./...` clean on this branch.

Made with [Cursor](https://cursor.com)