### PR TITLE
feat(frontend): wire FE to custom Go auth + drop better-auth/react

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -26,7 +26,6 @@
         "@types/react": "^18.2.21",
         "@types/react-dom": "^18.2.7",
         "@types/uuid": "^9.0.3",
-        "better-auth": "^1.6.9",
         "bootstrap": "^5.3.3",
         "chart.js": "^4.3.3",
         "class-variance-authority": "^0.7.0",
@@ -2261,102 +2260,6 @@
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
       "license": "MIT"
     },
-    "node_modules/@better-auth/core": {
-      "version": "1.6.9",
-      "resolved": "https://registry.npmjs.org/@better-auth/core/-/core-1.6.9.tgz",
-      "integrity": "sha512-ADFk5pwmLybmc+LvYvXJ6M1x2oY/EyYLkwLuH0x28FUq12DfjL0wnE7g+WRDf3yozDO+qIxTpFGXDGwLKbfz0w==",
-      "license": "MIT",
-      "dependencies": {
-        "@opentelemetry/semantic-conventions": "^1.39.0",
-        "@standard-schema/spec": "^1.1.0",
-        "zod": "^4.3.6"
-      },
-      "peerDependencies": {
-        "@better-auth/utils": "0.4.0",
-        "@better-fetch/fetch": "1.1.21",
-        "@cloudflare/workers-types": ">=4",
-        "@opentelemetry/api": "^1.9.0",
-        "better-call": "1.3.5",
-        "jose": "^6.1.0",
-        "kysely": "^0.28.5",
-        "nanostores": "^1.0.1"
-      },
-      "peerDependenciesMeta": {
-        "@cloudflare/workers-types": {
-          "optional": true
-        },
-        "@opentelemetry/api": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@better-auth/kysely-adapter": {
-      "version": "1.6.9",
-      "resolved": "https://registry.npmjs.org/@better-auth/kysely-adapter/-/kysely-adapter-1.6.9.tgz",
-      "integrity": "sha512-gyjuuxJtZ4o9G9z9q4kqn24X2kvMSp7F+KHogYxF03SnXY/2WleAcuj57iC4wP3e9mGDbjPOrnM5K6Kr3Ktdpw==",
-      "license": "MIT",
-      "peerDependencies": {
-        "@better-auth/core": "^1.6.9",
-        "@better-auth/utils": "0.4.0",
-        "kysely": "^0.28.14"
-      },
-      "peerDependenciesMeta": {
-        "kysely": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@better-auth/memory-adapter": {
-      "version": "1.6.9",
-      "resolved": "https://registry.npmjs.org/@better-auth/memory-adapter/-/memory-adapter-1.6.9.tgz",
-      "integrity": "sha512-XmIG4tUnOXZ+KEcWjHUjOI9Z5donD09dC2t/AQTXifAUIqx7cySg86w0KTM09ArzAxRx1fCqO36Wkt5nULnrkQ==",
-      "license": "MIT",
-      "peerDependencies": {
-        "@better-auth/core": "^1.6.9",
-        "@better-auth/utils": "0.4.0"
-      }
-    },
-    "node_modules/@better-auth/mongo-adapter": {
-      "version": "1.6.9",
-      "resolved": "https://registry.npmjs.org/@better-auth/mongo-adapter/-/mongo-adapter-1.6.9.tgz",
-      "integrity": "sha512-h+AiRJ/TsBSi+ZDjySASBpbJ/9QCXBre34PSKgCz7QmTHrFM9Cg2EM4AM7LjR5lPXipEE+2rWPBc9wfnUBjhcw==",
-      "license": "MIT",
-      "peerDependencies": {
-        "@better-auth/core": "^1.6.9",
-        "@better-auth/utils": "0.4.0",
-        "mongodb": "^6.0.0 || ^7.0.0"
-      },
-      "peerDependenciesMeta": {
-        "mongodb": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@better-auth/telemetry": {
-      "version": "1.6.9",
-      "resolved": "https://registry.npmjs.org/@better-auth/telemetry/-/telemetry-1.6.9.tgz",
-      "integrity": "sha512-0u5zkhSCAQFoN3DHvUkLHOF6MBbVTDAa6mU8mhPwiysdz1x21vMzhzfaAKN/ZGWaQ09v91/F+2qu42G/bhUV4A==",
-      "license": "MIT",
-      "peerDependencies": {
-        "@better-auth/core": "^1.6.9",
-        "@better-auth/utils": "0.4.0",
-        "@better-fetch/fetch": "1.1.21"
-      }
-    },
-    "node_modules/@better-auth/utils": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/@better-auth/utils/-/utils-0.4.0.tgz",
-      "integrity": "sha512-RpMtLUIQAEWMgdPLNVbIF5ON2mm+CH0U3rCdUCU1VyeAUui4m38DyK7/aXMLZov2YDjG684pS1D0MBllrmgjQA==",
-      "license": "MIT",
-      "dependencies": {
-        "@noble/hashes": "^2.0.1"
-      }
-    },
-    "node_modules/@better-fetch/fetch": {
-      "version": "1.1.21",
-      "resolved": "https://registry.npmjs.org/@better-fetch/fetch/-/fetch-1.1.21.tgz",
-      "integrity": "sha512-/ImESw0sskqlVR94jB+5+Pxjf+xBwDZF/N5+y2/q4EqD7IARUTSpPfIo8uf39SYpCxyOCtbyYpUrZ3F/k0zT4A=="
-    },
     "node_modules/@csstools/normalize.css": {
       "version": "12.1.1",
       "resolved": "https://registry.npmjs.org/@csstools/normalize.css/-/normalize.css-12.1.1.tgz",
@@ -3365,30 +3268,6 @@
         "node": ">=4.0"
       }
     },
-    "node_modules/@noble/ciphers": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@noble/ciphers/-/ciphers-2.2.0.tgz",
-      "integrity": "sha512-Z6pjIZ/8IJcCGzb2S/0Px5J81yij85xASuk1teLNeg75bfT07MV3a/O2Mtn1I2se43k3lkVEcFaR10N4cgQcZA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 20.19.0"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
-    "node_modules/@noble/hashes": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.2.0.tgz",
-      "integrity": "sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 20.19.0"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -3422,15 +3301,6 @@
       },
       "engines": {
         "node": ">= 8"
-      }
-    },
-    "node_modules/@opentelemetry/semantic-conventions": {
-      "version": "1.40.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.40.0.tgz",
-      "integrity": "sha512-cifvXDhcqMwwTlTK04GBNeIe7yyo28Mfby85QXFe1Yk8nmi36Ab/5UQwptOx84SsoGNRg+EVSjwzfSZMy6pmlw==",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=14"
       }
     },
     "node_modules/@pkgjs/parseargs": {
@@ -4205,12 +4075,6 @@
       "dependencies": {
         "@sinonjs/commons": "^1.7.0"
       }
-    },
-    "node_modules/@standard-schema/spec": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
-      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
-      "license": "MIT"
     },
     "node_modules/@supabase/auth-js": {
       "version": "2.64.4",
@@ -6340,167 +6204,6 @@
       "integrity": "sha512-x+VAiMRL6UPkx+kudNvxTl6hB2XNNCG2r+7wixVfIYwu/2HKRXimwQyaumLjMveWvT2Hkd/cAJw+QBMfJ/EKVw==",
       "license": "MIT"
     },
-    "node_modules/better-auth": {
-      "version": "1.6.9",
-      "resolved": "https://registry.npmjs.org/better-auth/-/better-auth-1.6.9.tgz",
-      "integrity": "sha512-EBFURtglyiEZxbx4NJBoqUD8J65dX24yC+6I9AUbIXNgUkt76mshzGbHkxZ3n/lB7Dwq3kBC+hHt0hUQsnL7HA==",
-      "license": "MIT",
-      "dependencies": {
-        "@better-auth/core": "1.6.9",
-        "@better-auth/drizzle-adapter": "1.6.9",
-        "@better-auth/kysely-adapter": "1.6.9",
-        "@better-auth/memory-adapter": "1.6.9",
-        "@better-auth/mongo-adapter": "1.6.9",
-        "@better-auth/prisma-adapter": "1.6.9",
-        "@better-auth/telemetry": "1.6.9",
-        "@better-auth/utils": "0.4.0",
-        "@better-fetch/fetch": "1.1.21",
-        "@noble/ciphers": "^2.1.1",
-        "@noble/hashes": "^2.0.1",
-        "better-call": "1.3.5",
-        "defu": "^6.1.4",
-        "jose": "^6.1.3",
-        "kysely": "^0.28.14",
-        "nanostores": "^1.1.1",
-        "zod": "^4.3.6"
-      },
-      "peerDependencies": {
-        "@lynx-js/react": "*",
-        "@prisma/client": "^5.0.0 || ^6.0.0 || ^7.0.0",
-        "@sveltejs/kit": "^2.0.0",
-        "@tanstack/react-start": "^1.0.0",
-        "@tanstack/solid-start": "^1.0.0",
-        "better-sqlite3": "^12.0.0",
-        "drizzle-kit": ">=0.31.4",
-        "drizzle-orm": "^0.45.2",
-        "mongodb": "^6.0.0 || ^7.0.0",
-        "mysql2": "^3.0.0",
-        "next": "^14.0.0 || ^15.0.0 || ^16.0.0",
-        "pg": "^8.0.0",
-        "prisma": "^5.0.0 || ^6.0.0 || ^7.0.0",
-        "react": "^18.0.0 || ^19.0.0",
-        "react-dom": "^18.0.0 || ^19.0.0",
-        "solid-js": "^1.0.0",
-        "svelte": "^4.0.0 || ^5.0.0",
-        "vitest": "^2.0.0 || ^3.0.0 || ^4.0.0",
-        "vue": "^3.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@lynx-js/react": {
-          "optional": true
-        },
-        "@prisma/client": {
-          "optional": true
-        },
-        "@sveltejs/kit": {
-          "optional": true
-        },
-        "@tanstack/react-start": {
-          "optional": true
-        },
-        "@tanstack/solid-start": {
-          "optional": true
-        },
-        "better-sqlite3": {
-          "optional": true
-        },
-        "drizzle-kit": {
-          "optional": true
-        },
-        "drizzle-orm": {
-          "optional": true
-        },
-        "mongodb": {
-          "optional": true
-        },
-        "mysql2": {
-          "optional": true
-        },
-        "next": {
-          "optional": true
-        },
-        "pg": {
-          "optional": true
-        },
-        "prisma": {
-          "optional": true
-        },
-        "react": {
-          "optional": true
-        },
-        "react-dom": {
-          "optional": true
-        },
-        "solid-js": {
-          "optional": true
-        },
-        "svelte": {
-          "optional": true
-        },
-        "vitest": {
-          "optional": true
-        },
-        "vue": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/better-auth/node_modules/@better-auth/drizzle-adapter": {
-      "version": "1.6.9",
-      "resolved": "https://registry.npmjs.org/@better-auth/drizzle-adapter/-/drizzle-adapter-1.6.9.tgz",
-      "integrity": "sha512-Lcco5hOGrMgc4XKAkvB6x72eQm4wCcya8IevMg4wBHY9W9GVg8pu23rpRX6VsVQSO4Ux13S7lFwUWtF7/r9aKw==",
-      "license": "MIT",
-      "peerDependencies": {
-        "@better-auth/core": "^1.6.9",
-        "@better-auth/utils": "0.4.0",
-        "drizzle-orm": "^0.45.2"
-      },
-      "peerDependenciesMeta": {
-        "drizzle-orm": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/better-auth/node_modules/@better-auth/prisma-adapter": {
-      "version": "1.6.9",
-      "resolved": "https://registry.npmjs.org/@better-auth/prisma-adapter/-/prisma-adapter-1.6.9.tgz",
-      "integrity": "sha512-XHks01ntK20orqK/jICq8wmEbJ/zT6dct49Fk8zTQKN9QNGDc+Ix5+7z/Kvui0DXGFf790GfvRozquzaLtXa8Q==",
-      "license": "MIT",
-      "peerDependencies": {
-        "@better-auth/core": "^1.6.9",
-        "@better-auth/utils": "0.4.0",
-        "@prisma/client": "^5.0.0 || ^6.0.0 || ^7.0.0",
-        "prisma": "^5.0.0 || ^6.0.0 || ^7.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@prisma/client": {
-          "optional": true
-        },
-        "prisma": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/better-call": {
-      "version": "1.3.5",
-      "resolved": "https://registry.npmjs.org/better-call/-/better-call-1.3.5.tgz",
-      "integrity": "sha512-kOFJkBP7utAQLEYrobZm3vkTH8mXq5GNgvjc5/XEST1ilVHaxXUXfeDeFlqoETMtyqS4+3/h4ONX2i++ebZrvA==",
-      "license": "MIT",
-      "dependencies": {
-        "@better-auth/utils": "^0.4.0",
-        "@better-fetch/fetch": "^1.1.21",
-        "rou3": "^0.7.12",
-        "set-cookie-parser": "^3.0.1"
-      },
-      "peerDependencies": {
-        "zod": "^4.0.0"
-      },
-      "peerDependenciesMeta": {
-        "zod": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/bfj": {
       "version": "7.1.0",
       "resolved": "https://registry.npmjs.org/bfj/-/bfj-7.1.0.tgz",
@@ -8211,12 +7914,6 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
-    },
-    "node_modules/defu": {
-      "version": "6.1.7",
-      "resolved": "https://registry.npmjs.org/defu/-/defu-6.1.7.tgz",
-      "integrity": "sha512-7z22QmUWiQ/2d0KkdYmANbRUVABpZ9SNYyH5vx6PZ+nE5bcC0l7uFvEfHlyld/HcGBFTL536ClDt3DEcSlEJAQ==",
-      "license": "MIT"
     },
     "node_modules/delayed-stream": {
       "version": "1.0.0",
@@ -12616,15 +12313,6 @@
         "jiti": "bin/jiti.js"
       }
     },
-    "node_modules/jose": {
-      "version": "6.2.2",
-      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.2.tgz",
-      "integrity": "sha512-d7kPDd34KO/YnzaDOlikGpOurfF0ByC2sEV4cANCtdqLlTfBlw2p14O/5d/zv40gJPbIQxfES3nSx1/oYNyuZQ==",
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/panva"
-      }
-    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -13050,15 +12738,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 8"
-      }
-    },
-    "node_modules/kysely": {
-      "version": "0.28.16",
-      "resolved": "https://registry.npmjs.org/kysely/-/kysely-0.28.16.tgz",
-      "integrity": "sha512-3i5pmOiZvMDj00qhrIVbH0AnioVTx22DMP7Vn5At4yJO46iy+FM8Y/g61ltenLVSo3fiO8h8Q3QOFgf/gQ72ww==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=20.0.0"
       }
     },
     "node_modules/language-subtag-registry": {
@@ -13610,21 +13289,6 @@
       },
       "engines": {
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
-      }
-    },
-    "node_modules/nanostores": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/nanostores/-/nanostores-1.3.0.tgz",
-      "integrity": "sha512-XPUa/jz+P1oJvN9VBxw4L9MtdFfaH3DAryqPssqhb2kXjmb9npz0dly6rCsgFWOPr4Yg9mTfM3MDZgZZ+7A3lA==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "license": "MIT",
-      "engines": {
-        "node": "^20.0.0 || >=22.0.0"
       }
     },
     "node_modules/natural-compare": {
@@ -16906,12 +16570,6 @@
         "randombytes": "^2.1.0"
       }
     },
-    "node_modules/rou3": {
-      "version": "0.7.12",
-      "resolved": "https://registry.npmjs.org/rou3/-/rou3-0.7.12.tgz",
-      "integrity": "sha512-iFE4hLDuloSWcD7mjdCDhx2bKcIsYbtOTpfH5MHHLSKMOUyjqQXTeZVa289uuwEGEKFoE/BAPbhaU4B774nceg==",
-      "license": "MIT"
-    },
     "node_modules/run-parallel": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
@@ -17452,12 +17110,6 @@
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
       "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/set-cookie-parser": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-3.1.0.tgz",
-      "integrity": "sha512-kjnC1DXBHcxaOaOXBHBeRtltsDG2nUiUni+jP92M9gYdW12rsmx92UsfpH7o5tDRs7I1ZZPSQJQGv3UaRfCiuw==",
       "license": "MIT"
     },
     "node_modules/set-function-length": {
@@ -20420,15 +20072,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/zod": {
-      "version": "4.3.6",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
-      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/colinhacks"
       }
     }
   }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -21,7 +21,6 @@
     "@types/react": "^18.2.21",
     "@types/react-dom": "^18.2.7",
     "@types/uuid": "^9.0.3",
-    "better-auth": "^1.6.9",
     "bootstrap": "^5.3.3",
     "chart.js": "^4.3.3",
     "class-variance-authority": "^0.7.0",

--- a/frontend/src/auth.tsx
+++ b/frontend/src/auth.tsx
@@ -1,20 +1,18 @@
 import React, { createContext, useCallback, useContext, useEffect, useMemo, useState } from "react";
-import { createAuthClient } from "better-auth/react";
-import { emailOTPClient, phoneNumberClient } from "better-auth/client/plugins";
 import { endpoint } from "./config";
 
-// The auth-service is mounted at /api/auth on the same domain as the Go API
-// (same Fly machine). In local dev that means localhost:3009, in prod the
-// Fly hostname. We reuse `endpoint` so this stays in sync with every other
-// API call in the app.
-const authClient = createAuthClient({
-  baseURL: endpoint,
-  plugins: [emailOTPClient(), phoneNumberClient()],
-});
+// Talks directly to the new Go auth package's /auth/* endpoints. No SDK,
+// no JWT, no token refresh logic — the browser holds an HttpOnly session
+// cookie that auto-attaches on cross-origin fetches that opt in via
+// `credentials: "include"`.
+//
+// `AppSession.access_token` is kept on the type for backward-compat with
+// existing call sites that send `Authorization: Bearer ${access_token}`.
+// The header is now ignored by the backend (cookie middleware sets
+// userAccountID first; the legacy JWT path is short-circuited). We leave
+// the field as an empty string rather than removing it so we don't have
+// to refactor every fetch in the codebase in this PR.
 
-// Shape kept compatible with existing call sites (`session.access_token`,
-// `session.user.id`, etc.) so the wider app didn't have to change. The
-// access token is fetched on demand from Better Auth's JWT plugin endpoint.
 export interface AppUser {
   id: string;
   email?: string | null;
@@ -30,6 +28,9 @@ export interface AppSession {
 
 interface SignInApi {
   google: () => Promise<void>;
+  // Email OTP is not implemented in the new backend (Better Auth's email
+  // flow was disabled by feature flag too). Stubs preserved so call sites
+  // compile; calling them throws.
   sendEmailOtp: (email: string) => Promise<void>;
   verifyEmailOtp: (email: string, otp: string) => Promise<void>;
   sendSmsOtp: (phoneNumber: string) => Promise<void>;
@@ -40,9 +41,9 @@ interface AuthContextValue {
   loading: boolean;
   user: AppUser | null;
   session: AppSession | null;
-  // True iff Better Auth knows about a user but we couldn't fetch the JWT
-  // we need to call protected APIs. Distinct from "logged out" (user==null)
-  // and from "still loading" (loading==true).
+  // Always false now. Kept on the type so consumers that branch on it
+  // still compile; the JWT-fetch failure mode it represented can't
+  // happen with cookie-only auth.
   tokenError: boolean;
   signIn: SignInApi;
   signOut: () => Promise<void>;
@@ -51,8 +52,12 @@ interface AuthContextValue {
 
 const defaultSignIn: SignInApi = {
   google: async () => {},
-  sendEmailOtp: async () => {},
-  verifyEmailOtp: async () => {},
+  sendEmailOtp: async () => {
+    throw new Error("email OTP is not enabled");
+  },
+  verifyEmailOtp: async () => {
+    throw new Error("email OTP is not enabled");
+  },
   sendSmsOtp: async () => {},
   verifySmsOtp: async () => {},
 };
@@ -67,118 +72,95 @@ const AuthContext = createContext<AuthContextValue>({
   refreshToken: async () => null,
 });
 
-const fetchAccessToken = async (): Promise<string | null> => {
-  try {
-    const resp = await fetch(`${endpoint}/api/auth/token`, { credentials: "include" });
-    if (!resp.ok) return null;
-    const body = (await resp.json()) as { token?: string };
-    return body.token ?? null;
-  } catch {
-    return null;
-  }
-};
+const COMMON: RequestInit = { credentials: "include" };
 
 interface AuthProviderProps {
   children: React.ReactNode;
 }
 
 const AuthProvider = ({ children }: AuthProviderProps) => {
-  const { data, isPending, refetch } = authClient.useSession();
-  const [accessToken, setAccessToken] = useState<string | null>(null);
-  // Tracks the "I have a session but I'm still fetching the JWT" window so
-  // page-level guards don't briefly see (loading=false, session=null) on
-  // refresh and pop a login modal at an already-authenticated user.
-  const [tokenLoading, setTokenLoading] = useState<boolean>(false);
+  const [user, setUser] = useState<AppUser | null>(null);
+  const [loading, setLoading] = useState<boolean>(true);
 
-  const sessionUser = data?.user as AppUser | undefined;
-
-  const sessionUserId = sessionUser?.id ?? null;
-  useEffect(() => {
-    let cancelled = false;
-    if (!sessionUserId) {
-      setAccessToken(null);
-      setTokenLoading(false);
-      return;
-    }
-    setTokenLoading(true);
-    fetchAccessToken().then((token) => {
-      if (cancelled) return;
-      setAccessToken(token);
-      setTokenLoading(false);
-      if (!token) {
-        // User is logged in (server knows them) but we couldn't get a JWT.
-        // Most likely cause: cross-origin cookie blocked by the browser.
-        // Surface in console so a developer notices, and `tokenError`
-        // exposes the state to consumers (so they can show a banner or
-        // force a re-auth instead of looking superficially logged in).
-        // eslint-disable-next-line no-console
-        console.warn("[auth] session present but JWT fetch failed");
+  const refresh = useCallback(async () => {
+    try {
+      const r = await fetch(`${endpoint}/auth/session`, COMMON);
+      if (!r.ok) {
+        setUser(null);
+        return;
       }
-    });
-    return () => {
-      cancelled = true;
-    };
-  }, [sessionUserId]);
-
-  const refreshToken = useCallback(async () => {
-    const token = await fetchAccessToken();
-    setAccessToken(token);
-    return token;
+      const body = (await r.json()) as { user: AppUser | null };
+      setUser(body.user);
+    } catch {
+      setUser(null);
+    } finally {
+      setLoading(false);
+    }
   }, []);
 
+  useEffect(() => {
+    void refresh();
+  }, [refresh]);
+
   const signOut = useCallback(async () => {
-    await authClient.signOut();
-    await refetch();
-  }, [refetch]);
+    await fetch(`${endpoint}/auth/sign-out`, {
+      ...COMMON,
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+    });
+    await refresh();
+  }, [refresh]);
 
   const signIn: SignInApi = useMemo(
     () => ({
       google: async () => {
-        await authClient.signIn.social({
-          provider: "google",
-          callbackURL: window.location.href,
-        });
+        // Top-level redirect (not a fetch) so the browser follows Google's
+        // OAuth flow naturally and lands the session cookie when it returns.
+        window.location.assign(`${endpoint}/auth/google/start`);
       },
-      sendEmailOtp: async (email) => {
-        const { error } = await authClient.emailOtp.sendVerificationOtp({
-          email,
-          type: "sign-in",
-        });
-        if (error) throw new Error(error.message ?? "failed to send email OTP");
+      sendEmailOtp: async () => {
+        throw new Error("email OTP is not enabled");
       },
-      verifyEmailOtp: async (email, otp) => {
-        const { error } = await authClient.signIn.emailOtp({ email, otp });
-        if (error) throw new Error(error.message ?? "invalid email OTP");
-        await refetch();
+      verifyEmailOtp: async () => {
+        throw new Error("email OTP is not enabled");
       },
       sendSmsOtp: async (phoneNumber) => {
-        const { error } = await authClient.phoneNumber.sendOtp({ phoneNumber });
-        if (error) throw new Error(error.message ?? "failed to send SMS OTP");
+        const r = await fetch(`${endpoint}/auth/sms/send`, {
+          ...COMMON,
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ phoneNumber }),
+        });
+        // /auth/sms/send always 204 — uniform response, no enumeration leak.
+        // Origin allowlist mismatch (403) is the only meaningful failure.
+        if (r.status === 403) throw new Error("origin not allowed");
+        if (!r.ok && r.status !== 204) throw new Error("failed to send SMS OTP");
       },
       verifySmsOtp: async (phoneNumber, code) => {
-        const { error } = await authClient.phoneNumber.verify({ phoneNumber, code });
-        if (error) throw new Error(error.message ?? "invalid SMS OTP");
-        await refetch();
+        const r = await fetch(`${endpoint}/auth/sms/verify`, {
+          ...COMMON,
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ phoneNumber, code }),
+        });
+        if (r.status === 401) throw new Error("invalid SMS OTP");
+        if (!r.ok && r.status !== 204) throw new Error("failed to verify SMS OTP");
+        await refresh();
       },
     }),
-    [refetch],
+    [refresh],
   );
 
-  const session: AppSession | null =
-    sessionUser && accessToken
-      ? { access_token: accessToken, user: sessionUser }
-      : null;
-
-  const tokenError = Boolean(sessionUserId) && !tokenLoading && !accessToken;
+  const session: AppSession | null = user ? { access_token: "", user } : null;
 
   const value: AuthContextValue = {
-    loading: isPending || tokenLoading,
-    user: sessionUser ?? null,
+    loading,
+    user,
     session,
-    tokenError,
+    tokenError: false,
     signIn,
     signOut,
-    refreshToken,
+    refreshToken: async () => "",
   };
 
   return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;

--- a/frontend/src/common/AuthModals.tsx
+++ b/frontend/src/common/AuthModals.tsx
@@ -15,7 +15,7 @@ import { cn } from "@/lib/utils";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { AlertCircle } from "lucide-react";
 
-type PageState = "initial" | "smsConfirmation" | "emailConfirmation";
+type PageState = "initial" | "smsConfirmation";
 
 export default function LoginModal({
   show,
@@ -29,7 +29,6 @@ export default function LoginModal({
   const { signIn } = useAuth();
   const [pageState, setPageState] = useState<PageState>("initial");
   const [phoneNumber, setPhoneNumber] = useState<string>("");
-  const [email, setEmail] = useState<string>("");
   const [loading, setLoading] = useState<boolean>(false);
   const [error, setError] = useState<string>("");
 
@@ -62,20 +61,6 @@ export default function LoginModal({
     }
   };
 
-  const handleEmailRequest = async (e: React.FormEvent<HTMLFormElement>) => {
-    e.preventDefault();
-    setLoading(true);
-    setError("");
-    try {
-      await signIn.sendEmailOtp(email);
-      setPageState("emailConfirmation");
-    } catch (e: unknown) {
-      setError(e instanceof Error ? e.message : "Failed to send email code");
-    } finally {
-      setLoading(false);
-    }
-  };
-
   return (
     <Dialog
       open={show}
@@ -102,13 +87,10 @@ export default function LoginModal({
 
         {pageState === "initial" && (
           <InitialPanel
-            email={email}
-            setEmail={setEmail}
             phoneNumber={phoneNumber}
             setPhoneNumber={setPhoneNumber}
             onGoogle={handleGoogle}
             onSmsRequest={handleSmsRequest}
-            onEmailRequest={handleEmailRequest}
             loading={loading}
           />
         )}
@@ -116,17 +98,6 @@ export default function LoginModal({
         {pageState === "smsConfirmation" && (
           <SmsConfirmationPanel
             phoneNumber={phoneNumber}
-            setError={setError}
-            onSuccess={() => {
-              onSuccess?.();
-              close();
-            }}
-          />
-        )}
-
-        {pageState === "emailConfirmation" && (
-          <EmailConfirmationPanel
-            email={email}
             setError={setError}
             onSuccess={() => {
               onSuccess?.();
@@ -160,22 +131,16 @@ function Spinner() {
 }
 
 function InitialPanel({
-  email,
-  setEmail,
   phoneNumber,
   setPhoneNumber,
   onGoogle,
   onSmsRequest,
-  onEmailRequest,
   loading,
 }: {
-  email: string;
-  setEmail: (v: string) => void;
   phoneNumber: string;
   setPhoneNumber: (v: any) => void;
   onGoogle: () => void;
   onSmsRequest: (e: React.FormEvent<HTMLFormElement>) => void;
-  onEmailRequest: (e: React.FormEvent<HTMLFormElement>) => void;
   loading: boolean;
 }) {
   return (
@@ -183,26 +148,6 @@ function InitialPanel({
       <Button onClick={onGoogle} type="button" className="w-full" disabled={loading}>
         Continue with Google
       </Button>
-
-      <Divider label="or email" />
-
-      <form onSubmit={onEmailRequest}>
-        <div className="grid gap-3">
-          <div className="grid gap-2">
-            <Label>Email</Label>
-            <Input
-              type="email"
-              placeholder="you@example.com"
-              required
-              value={email}
-              onChange={(e) => setEmail(e.target.value)}
-            />
-          </div>
-          <Button disabled={loading || !email.includes("@")} type="submit" className="w-full">
-            Email me a code
-          </Button>
-        </div>
-      </form>
 
       <Divider label="or phone" />
 
@@ -279,57 +224,6 @@ function SmsConfirmationPanel({
       <div className="grid gap-4">
         <div className="grid gap-2">
           <Label>SMS Confirmation Code</Label>
-          <Input
-            autoFocus
-            required
-            type="number"
-            value={code}
-            onChange={(e) => {
-              setError("");
-              setCode(e.target.value);
-            }}
-          />
-        </div>
-        <Button disabled={submitting || code.length !== 6} type="submit" className="w-full">
-          Continue
-        </Button>
-      </div>
-    </form>
-  );
-}
-
-function EmailConfirmationPanel({
-  email,
-  setError,
-  onSuccess,
-}: {
-  email: string;
-  setError: React.Dispatch<React.SetStateAction<string>>;
-  onSuccess: () => void;
-}) {
-  const { signIn } = useAuth();
-  const [code, setCode] = useState("");
-  const [submitting, setSubmitting] = useState(false);
-
-  const onSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
-    e.preventDefault();
-    if (submitting) return;
-    setSubmitting(true);
-    try {
-      await signIn.verifyEmailOtp(email, code);
-      onSuccess();
-    } catch (err: unknown) {
-      setError(err instanceof Error ? err.message : "Invalid code");
-    } finally {
-      setSubmitting(false);
-    }
-  };
-
-  return (
-    <form onSubmit={onSubmit}>
-      <div className="grid gap-4">
-        <div className="grid gap-2">
-          <Label>Email Confirmation Code</Label>
           <Input
             autoFocus
             required

--- a/frontend/src/common/Footer.tsx
+++ b/frontend/src/common/Footer.tsx
@@ -14,6 +14,7 @@ export default function StatsFooter({ userID, user }: { userID: string, user: Go
   async function getStats() {
     try {
       const response = await fetch(endpoint + "/usageStats?id=" + userID, {
+        credentials: "include",
         headers: {
           "Authorization": session ? "Bearer " + session.access_token : ""
         }

--- a/frontend/src/common/Modals.tsx
+++ b/frontend/src/common/Modals.tsx
@@ -83,6 +83,7 @@ function ContactForm() {
     try {
       const response = await fetch(endpoint + "/contact", {
         method: 'POST',
+        credentials: "include",
         headers: {
           'Content-Type': 'application/json',
           "Authorization": session ? "Bearer " + session.access_token : ""

--- a/frontend/src/pages/Backtest/Backtest.tsx
+++ b/frontend/src/pages/Backtest/Backtest.tsx
@@ -76,6 +76,7 @@ export default function FactorBacktestMain({ userID, user, setUser }: {
   async function getStrategy(id: string): Promise<GetPublishedStrategiesResponse | null> {
     try {
       const response = await fetch(endpoint + "/publishedStrategies", {
+        credentials: "include",
         headers: {
           "Authorization": session ? "Bearer " + session.access_token : ""
         }

--- a/frontend/src/pages/Backtest/FactorExpressionInput.tsx
+++ b/frontend/src/pages/Backtest/FactorExpressionInput.tsx
@@ -48,6 +48,7 @@ export function FactorExpressionInput({
     try {
       const response = await fetch(endpoint + "/constructFactorEquation", {
         method: "POST",
+        credentials: "include",
         headers: {
           "Content-Type": "application/json",
           "Authorization": session ? "Bearer " + session.access_token : ""

--- a/frontend/src/pages/Backtest/Form.tsx
+++ b/frontend/src/pages/Backtest/Form.tsx
@@ -29,6 +29,7 @@ async function getIsBookmarked(session: Session, props: FormViewProps): Promise<
   try {
     const response = await fetch(endpoint + "/isStrategyBookmarked", {
       method: "POST",
+      credentials: "include",
       headers: {
         "Authorization": session ? "Bearer " + session.access_token : ""
       },
@@ -52,6 +53,7 @@ async function getIsBookmarked(session: Session, props: FormViewProps): Promise<
 export async function getStrategies(session: Session, setSavedStrategies: Dispatch<React.SetStateAction<GetSavedStrategiesResponse[]>>) {
   try {
     const response = await fetch(endpoint + "/savedStrategies", {
+      credentials: "include",
       headers: {
         "Authorization": session ? "Bearer " + session.access_token : ""
       }
@@ -150,6 +152,7 @@ export default function FactorForm({
   const getUniverses = async () => {
     try {
       const response = await fetch(endpoint + "/assetUniverses", {
+        credentials: "include",
         headers: {
           "Authorization": session ? "Bearer " + session.access_token : ""
         }
@@ -235,6 +238,7 @@ export default function FactorForm({
     try {
       const response = await fetch(endpoint + "/backtest", {
         method: "POST",
+        credentials: "include",
         headers: {
           "Content-Type": "application/json",
           "Authorization": session ? "Bearer " + session.access_token : ""
@@ -801,6 +805,7 @@ export const updateBookmarked = async (
   try {
     const response = await fetch(endpoint + "/bookmarkStrategy", {
       method: "POST",
+      credentials: "include",
       headers: {
         "Authorization": session ? "Bearer " + session.access_token : ""
       },

--- a/frontend/src/pages/Backtest/InvestInStrategy.tsx
+++ b/frontend/src/pages/Backtest/InvestInStrategy.tsx
@@ -223,6 +223,7 @@ function InvestModal({
     try {
       const response = await fetch(endpoint + "/investInStrategy", {
         method: "POST",
+        credentials: "include",
         headers: {
           "Authorization": session ? "Bearer " + session.access_token : ""
         },

--- a/frontend/src/pages/Bond/Bond.tsx
+++ b/frontend/src/pages/Bond/Bond.tsx
@@ -120,6 +120,7 @@ function BondBuilderForm(
     try {
       const response = await fetch(endpoint + "/backtestBondPortfolio", {
         method: "POST",
+        credentials: "include",
         headers: {
           "Content-Type": "application/json",
           "Authorization": session ? "Bearer " + session.access_token : ""

--- a/frontend/src/pages/Home/Home.tsx
+++ b/frontend/src/pages/Home/Home.tsx
@@ -48,6 +48,7 @@ export function Home({
   async function getPublishedStrategies(): Promise<GetPublishedStrategiesResponse[]> {
     try {
       const response = await fetch(endpoint + "/publishedStrategies", {
+        credentials: "include",
         headers: {
           "Authorization": session ? "Bearer " + session.access_token : ""
         }

--- a/frontend/src/pages/Investments/Invest.tsx
+++ b/frontend/src/pages/Investments/Invest.tsx
@@ -40,6 +40,7 @@ export default function Invest({
   async function getInvestments() {
     try {
       const response = await fetch(endpoint + "/activeInvestments", {
+        credentials: "include",
         headers: {
           "Authorization": session ? "Bearer " + session.access_token : ""
         }

--- a/internal/auth/session.go
+++ b/internal/auth/session.go
@@ -89,9 +89,22 @@ func (s *Service) resolveSession(ctx context.Context, c *gin.Context) (uuid.UUID
 	return row.UserAccountID, true
 }
 
-// upsertGoogleUser is the only path Google sign-in takes to materialize a
-// user_account row. Identity is keyed on (LOCAL_GOOGLE, sub) — not email —
-// so email changes / recycling don't cause account collisions.
+// upsertGoogleUser materializes a user_account row from a Google-verified
+// identity. We use GetOrCreate (which keys lookup on email when present)
+// rather than GetOrCreateByProviderIdentity for the same reason
+// upsertPhoneUser uses GetOrCreate: the user_account.email column has its
+// own unique constraint that fires before our (provider, provider_id)
+// ON CONFLICT can update, when an existing row from a different provider
+// already holds that email.
+//
+// Email is set on the row only when Google's id_token has
+// email_verified=true; the OIDC verifier in google.go has already
+// enforced that. So `email` here is a Google-attested identity and
+// linking on it is the correct behavior — the user signing in with
+// Google can prove control of that mailbox.
+//
+// If email is empty (rare; would require a Google account with no email
+// scope granted), we fall back to provider+provider_id keyed insertion.
 func (s *Service) upsertGoogleUser(_ context.Context, sub, email, firstName, lastName string) (uuid.UUID, error) {
 	in := &model.UserAccount{
 		Provider:   model.UserAccountProviderType_LocalGoogle,
@@ -106,7 +119,15 @@ func (s *Service) upsertGoogleUser(_ context.Context, sub, email, firstName, las
 	if lastName != "" {
 		in.LastName = util.StringPointer(lastName)
 	}
-	row, err := s.users.GetOrCreateByProviderIdentity(in)
+	if email == "" {
+		// No email; only safe identity is the (provider, provider_id) tuple.
+		row, err := s.users.GetOrCreateByProviderIdentity(in)
+		if err != nil {
+			return uuid.Nil, err
+		}
+		return row.UserAccountID, nil
+	}
+	row, err := s.users.GetOrCreate(in)
 	if err != nil {
 		return uuid.Nil, err
 	}


### PR DESCRIPTION
## Summary

Pairs with #112 (custom Go auth backend). Rewires the FE off \`better-auth/react\` to talk directly to the new \`/auth/*\` endpoints via plain fetch + cookie auth. Removes the email OTP option from the login modal since the new backend doesn't implement it.

## What changed

**Two commits:**

- \`337850c fix(auth): upsertGoogleUser uses GetOrCreate to handle email collisions\` — caught during end-to-end testing. Same class of bug as the SMS upsert fix that landed in #112: the email unique constraint fires before the (provider, provider_id) ON CONFLICT can update, when an existing row from a different provider already holds that email. Falls back to GetOrCreate (email-keyed) when the Google id_token carries a verified email.

- \`aca9ff9 feat(frontend): swap better-auth/react for direct /auth/* fetches + remove email OTP UI\`

## Files

| File | Change |
|---|---|
| \`frontend/src/auth.tsx\` | 190 LOC → 155. Plain fetch against \`/auth/session\`, \`/auth/sign-out\`, \`/auth/sms/send\`, \`/auth/sms/verify\`. \`signIn.google()\` is now \`window.location.assign(\`\${endpoint}/auth/google/start\`)\`. \`AppSession.access_token\` kept as empty string for backward compat with call sites that send \`Authorization: Bearer\` (the header is harmless garbage now; cookie middleware wins). |
| \`frontend/src/common/AuthModals.tsx\` | Email OTP form + \`EmailConfirmationPanel\` removed. Modal is Google + SMS only. |
| 9 fetch call sites in pages/ and common/ | Add \`credentials: \"include\"\` so the browser auto-attaches the session cookie on cross-origin calls. CORS already had \`AllowCredentials: true\`. |
| \`frontend/package.json\` | Remove \`better-auth\` dependency. |
| \`internal/auth/session.go\` | upsertGoogleUser fallback to GetOrCreate. |

## Verified end-to-end against local stack

- Google OAuth: redirect to accounts.google.com, sign in, callback lands \`__Host-factor_session\` cookie, FE reflects logged-in state, /auth/session returns user
- SMS: \`+14088870718\` → Twilio sends code → verify → session cookie issued (note: SMS message template is currently misconfigured in Twilio console — code substitution missing — fix is in Twilio Verify settings, not code)
- Authenticated browsing: \`/publishedStrategies\`, \`/activeInvestments\` etc. carry the cookie cross-origin via credentials: include, return user-scoped data
- Sign-out: cookie cleared, FE reflects signed-out state

## Out of scope (follow-up PRs)

1. Delete \`auth-service/\`, \`scripts/start.sh\`, \`api/auth_proxy.go\`, the Better Auth \`auth.*\` schema, and the Node stage of \`Dockerfile.fly\` — once this PR is in prod and \`/api/auth/*\` traffic is zero
2. Twilio Verify SMS template fix (Twilio console; missing \`{{code}}\` substitution)
3. HSTS at CloudFront and Fly
4. Tests for the threat-model invariants in \`internal/auth/README.md\`

## Test plan

- [x] \`go build ./...\` clean
- [x] \`tsc --noEmit\` clean (pre-existing lint warnings unrelated to this PR)
- [x] \`npm uninstall better-auth\` cleanly drops dep
- [x] Manual end-to-end Google OAuth flow against local backend
- [x] Manual end-to-end SMS flow against local backend (real Twilio call)
- [x] Authenticated API calls work cross-origin
- [x] Sign-out invalidates the session
- [ ] Deploy + confirm prod flow (after merge)

Made with [Cursor](https://cursor.com)