### PR TITLE
feat(deploy): apply DB migrations on every Fly release

### DIFF
--- a/Dockerfile.fly
+++ b/Dockerfile.fly
@@ -1,8 +1,11 @@
-# Fly.io image: single Go API binary on a slim Debian base. tini reaps
-# zombies and forwards SIGTERM so Fly's stop signal is honored cleanly.
+# Fly.io image: Go API binary plus a sibling migrate binary on a slim Debian
+# base. tini reaps zombies and forwards SIGTERM so Fly's stop signal is honored
+# cleanly. The migrate binary is invoked by Fly's release_command (see
+# fly.toml) and embeds the migrations/ directory, so it doesn't need to ship
+# alongside the SQL files at runtime.
 
 # -----------------------------------------------------------------------------
-# Stage 1: build the Go API binary
+# Stage 1: build the Go binaries
 # -----------------------------------------------------------------------------
 FROM golang:1.25 AS go-build
 
@@ -17,6 +20,7 @@ ARG commit_hash
 ENV commit_hash=$commit_hash
 
 RUN GOARCH=amd64 GOOS=linux CGO_ENABLED=0 go build -o /out/api ./cmd/api
+RUN GOARCH=amd64 GOOS=linux CGO_ENABLED=0 go build -o /out/migrate ./cmd/migrate
 
 # -----------------------------------------------------------------------------
 # Stage 2: runtime image
@@ -28,6 +32,7 @@ WORKDIR /app
 RUN apt-get update && apt-get install -y --no-install-recommends tini ca-certificates && rm -rf /var/lib/apt/lists/*
 
 COPY --from=go-build /out/api /app/api
+COPY --from=go-build /out/migrate /app/migrate
 
 ARG commit_hash
 ENV commit_hash=$commit_hash

--- a/cmd/migrate/main.go
+++ b/cmd/migrate/main.go
@@ -1,0 +1,146 @@
+// Command migrate brings the production database forward to the migration
+// version embedded in the running binary. It's intended to run as Fly's
+// release_command: a temporary VM gets the same env-var secrets the API
+// process gets, runs this binary, and a non-zero exit aborts the deploy
+// before any new app VMs take traffic.
+//
+// The version-tracking scheme matches tools/migrations.py exactly so local
+// dev (Python, against the dockerized test DB) and prod (Go, against Fly's
+// Postgres) stay in lockstep:
+//
+//   - schema_version is a single-row table holding one int.
+//   - *.up.sql files are numbered NNNNNN_*.up.sql and applied in numeric
+//     order, but only those with a number strictly greater than the live
+//     value of schema_version.version.
+//   - The whole batch runs in one transaction; a failure rolls everything
+//     back, so prod stays at its previous version and the deploy aborts.
+package main
+
+import (
+	"database/sql"
+	"factorbacktest/internal/util"
+	"factorbacktest/migrations"
+	"fmt"
+	"io/fs"
+	"log"
+	"sort"
+	"strconv"
+	"strings"
+
+	_ "github.com/lib/pq"
+)
+
+func main() {
+	secrets, err := util.LoadSecrets()
+	if err != nil {
+		log.Fatalf("migrate: load secrets: %v", err)
+	}
+	db, err := sql.Open("postgres", secrets.Db.ToConnectionStr())
+	if err != nil {
+		log.Fatalf("migrate: open db: %v", err)
+	}
+	defer db.Close()
+	if err := db.Ping(); err != nil {
+		log.Fatalf("migrate: ping db: %v", err)
+	}
+
+	if err := run(db); err != nil {
+		log.Fatalf("migrate: %v", err)
+	}
+}
+
+func run(db *sql.DB) error {
+	tx, err := db.Begin()
+	if err != nil {
+		return fmt.Errorf("begin: %w", err)
+	}
+	// Safe to call after a successful Commit (becomes a no-op).
+	defer tx.Rollback()
+
+	current, err := ensureSchemaVersion(tx)
+	if err != nil {
+		return err
+	}
+	pending, err := pendingUpMigrations(current)
+	if err != nil {
+		return err
+	}
+	if len(pending) == 0 {
+		log.Printf("migrate: at version %d, nothing to apply", current)
+		return tx.Commit()
+	}
+
+	for _, m := range pending {
+		log.Printf("migrate: applying %s", m.filename)
+		if _, err := tx.Exec(m.sql); err != nil {
+			return fmt.Errorf("apply %s: %w", m.filename, err)
+		}
+		current = m.version
+	}
+	if _, err := tx.Exec(`UPDATE schema_version SET version = $1`, current); err != nil {
+		return fmt.Errorf("update schema_version: %w", err)
+	}
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("commit: %w", err)
+	}
+	log.Printf("migrate: at version %d", current)
+	return nil
+}
+
+// ensureSchemaVersion returns the live schema_version.version, bootstrapping
+// the table from 000000_schema_version.sql on a fresh database. Mirrors the
+// SAVEPOINT-based recovery in tools/migrations.py: if the SELECT errors
+// because the table doesn't exist, we apply the bootstrap script in the same
+// transaction and return version 0.
+func ensureSchemaVersion(tx *sql.Tx) (int, error) {
+	var v int
+	err := tx.QueryRow(`SELECT version FROM schema_version`).Scan(&v)
+	if err == nil {
+		return v, nil
+	}
+	bootstrap, readErr := fs.ReadFile(migrations.FS, "000000_schema_version.sql")
+	if readErr != nil {
+		return 0, fmt.Errorf("read bootstrap: %w", readErr)
+	}
+	if _, execErr := tx.Exec(string(bootstrap)); execErr != nil {
+		// Surface the original SELECT error too so we don't lose context if the
+		// bootstrap fails for some reason other than "table missing".
+		return 0, fmt.Errorf("bootstrap schema_version (after select error %v): %w", err, execErr)
+	}
+	return 0, nil
+}
+
+type migration struct {
+	version  int
+	filename string
+	sql      string
+}
+
+func pendingUpMigrations(current int) ([]migration, error) {
+	entries, err := fs.ReadDir(migrations.FS, ".")
+	if err != nil {
+		return nil, err
+	}
+	var out []migration
+	for _, e := range entries {
+		name := e.Name()
+		if !strings.HasSuffix(name, ".up.sql") {
+			continue
+		}
+		prefix := strings.SplitN(name, "_", 2)[0]
+		v, err := strconv.Atoi(prefix)
+		if err != nil {
+			return nil, fmt.Errorf("bad migration name %q: %w", name, err)
+		}
+		if v <= current {
+			continue
+		}
+		body, err := fs.ReadFile(migrations.FS, name)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, migration{version: v, filename: name, sql: string(body)})
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].version < out[j].version })
+	return out, nil
+}

--- a/fly.toml
+++ b/fly.toml
@@ -4,6 +4,14 @@ primary_region = "iad"
 [build]
   dockerfile = "Dockerfile.fly"
 
+[deploy]
+  # Run pending DB migrations before the new app version takes traffic. Fly
+  # runs this in a temp VM with full app secrets injected (FB_SECRETS_FROM_ENV
+  # gives the binary the same db creds the API uses). A non-zero exit aborts
+  # the release, so a broken migration leaves prod on the previous version
+  # rather than half-migrated.
+  release_command = "/app/migrate"
+
 [env]
   FB_SECRETS_FROM_ENV = "1"
   GIN_MODE = "release"

--- a/migrations/embed.go
+++ b/migrations/embed.go
@@ -1,0 +1,11 @@
+// Package migrations exposes the SQL migration files as an embedded FS so a
+// production binary (cmd/migrate) can apply them without the migrations/
+// directory needing to ship alongside it. The embed declaration has to live
+// here because go:embed patterns are resolved relative to the source file and
+// can't traverse upward with "..".
+package migrations
+
+import "embed"
+
+//go:embed *.sql
+var FS embed.FS

--- a/tools/migrations.py
+++ b/tools/migrations.py
@@ -57,7 +57,10 @@ def get_migration_filename(num, migration_type):
   return matched_files[0]
 
 def get_max_migration_num():
-  files = os.listdir()
+  # Only consider .sql files; the directory also holds non-migration files
+  # like embed.go (used by cmd/migrate to bake the SQL into the prod binary),
+  # which would otherwise sort to the end and break int() parsing.
+  files = [f for f in os.listdir() if f.endswith(".sql")]
   files = sorted(files)
   last_file = files[-1]
   migration_number_str = last_file.split("_")[0]


### PR DESCRIPTION
## Summary

- Adds `cmd/migrate`, a small Go binary that reuses `util.LoadSecrets` to talk to the same Postgres the API process talks to, then applies any embedded `*.up.sql` files whose number is greater than the live `schema_version.version`. Logic mirrors `tools/migrations.py` so local-dev (Python, test DB) and prod (Go, Fly DB) stay in lockstep.
- Wires it as `fly.toml`'s `release_command` so Fly runs it in a temp VM with full secrets after build, before traffic flips. Non-zero exit aborts the release and leaves prod on the previous version rather than half-migrated.
- Builds the new binary in `Dockerfile.fly`. Migrations are baked into the binary via `embed.FS` so the runtime image doesn't need the `migrations/` directory copied in.
- **No new GitHub secrets.** `FLY_API_TOKEN` remains the only deploy credential; DB creds never leave Fly.

## How it works on each deploy

1. Push to `master` triggers `.github/workflows/deploy-fly.yml` (unchanged).
2. `flyctl deploy --remote-only` builds the image with both `/app/api` and `/app/migrate`.
3. Fly spins up a temp VM, injects all app secrets, and runs `/app/migrate`. The binary reads `schema_version.version` once, applies any newer `.up.sql` files in numeric order inside a single transaction, updates the version, and exits.
4. Exit 0 → new VMs roll out. Non-zero → release aborted, old VMs keep serving.

## Notes

- Single-transaction batch matches `tools/migrations.py` behavior. None of the existing 54 migrations use non-transactional DDL like `CREATE INDEX CONCURRENTLY`; we'd need to revisit if that ever changes.
- First deploy after this lands will run migrate against prod; since `schema_version` is already at 54 and no new `.up.sql` files ship with this PR, it'll just log `at version 54, nothing to apply` and exit 0.
- Local dev unchanged — `make migrate` still drives `tools/migrations.py` against the dockerized test DB.

## Test plan

- [ ] `go build ./cmd/migrate` succeeds locally (verified)
- [ ] After merge: confirm the GH Actions deploy log shows the `release_command` step running and reporting `at version 54, nothing to apply`
- [ ] After merge: `fly ssh console -C 'psql ... -c "SELECT version FROM schema_version"'` (or equivalent) still returns 54
- [ ] On the next migration-bearing PR: confirm the new migration applies during `release_command` and the version increments

Made with [Cursor](https://cursor.com)