### PR TITLE
fix(frontend): send cookie on /benchmark and stop emitting empty Bearer

### DIFF
--- a/frontend/src/pages/Backtest/BenchmarkSelector.tsx
+++ b/frontend/src/pages/Backtest/BenchmarkSelector.tsx
@@ -42,9 +42,12 @@ export default function BenchmarkManager({
             endpoint + '/benchmark',
             {
               method: "POST",
+              credentials: "include",
               headers: {
                 "Content-Type": "application/json",
-                "Authorization": session ? "Bearer " + session.access_token : ""
+                ...(session && session.access_token
+                  ? { "Authorization": "Bearer " + session.access_token }
+                  : {}),
               },
               body: JSON.stringify({
                 userID,


### PR DESCRIPTION
## Summary

`BenchmarkSelector` was returning 403 `misformatted auth` from `/benchmark` for logged-in users after the initial render — it's the only fetch in the codebase missing `credentials: "include"`. Without the cookie, the backend's cookie middleware never set `userAccountID`, so `getGoogleAuthMiddleware` fell through to the Bearer path. Under cookie auth, `auth.tsx` keeps `session.access_token` as an empty-string backward-compat placeholder, so the header was built as `"Bearer " + ""` = `"Bearer "`. Go's `net/textproto` trims trailing whitespace from header values, so the backend saw `"Bearer"` (no space) and `HasPrefix("Bearer ")` returned false → 403.

The first load looked fine only because `user` was still null during the async `/auth/session` fetch, making `session` null and the Authorization header empty (which the backend treats as anonymous). Once the effect re-ran with a populated session, the bogus header went out.

- Add `credentials: "include"` so cookie auth runs and short-circuits before the Bearer check.
- Omit `Authorization` entirely when there's no real token, so we don't leave the same trap for the next refactor.

## Test plan

- [ ] Logged-in user: navigate to Backtest page, run a backtest, confirm `/benchmark` returns 200 on subsequent re-renders (no 403 misformatted auth).
- [ ] Logged-out user: confirm `/benchmark` still works anonymously.

Made with [Cursor](https://cursor.com)