### PR TITLE
feat(frontend): streaming backtest loading UX backed by SSE

### DIFF
--- a/frontend/src/common/BacktestLoading/BacktestLoadingOverlay.module.css
+++ b/frontend/src/common/BacktestLoading/BacktestLoadingOverlay.module.css
@@ -1,0 +1,211 @@
+/* Full-viewport scrim. We render via portal into document.body so this is
+   always on top of the rest of the SPA, regardless of the source page.
+   Fully opaque on purpose — translucent (0.96) lets the chart re-render
+   bleed through during the finishing hold, which made the overlay feel
+   like it was already dismissed even though it wasn't. */
+.scrim {
+  position: fixed;
+  inset: 0;
+  background-color: #ffffff;
+  z-index: 9999;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 24px;
+  /* fade in so the scrim doesn't snap. .14s feels live, not laggy. */
+  animation: scrim_fade 0.14s ease-out;
+}
+
+@keyframes scrim_fade {
+  from { opacity: 0; }
+  to { opacity: 1; }
+}
+
+.card {
+  width: 100%;
+  max-width: 480px;
+  background: #ffffff;
+  border: 1px solid #e6e8eb;
+  border-radius: 12px;
+  padding: 28px 32px;
+  box-shadow: 0 10px 30px rgba(15, 23, 42, 0.06);
+  font-family: inherit;
+}
+
+.title {
+  margin: 0 0 4px;
+  font-size: 18px;
+  font-weight: 600;
+  color: #0f172a;
+}
+
+.subtitle {
+  margin: 0 0 20px;
+  font-size: 13px;
+  color: #64748b;
+  /* Reserve the subtitle slot height so transitioning streaming → finishing
+     (where we drop the subtitle in favor of a bottom summary) doesn't make
+     the card jump up by 13px. */
+  min-height: 1.2em;
+}
+
+/* Completion line at the bottom of the card during the finishing hold.
+   Hairline divider above so it visually separates from the step list
+   without looking like an alert. Tabular-nums to keep the duration
+   readable at a glance. */
+.completion_summary {
+  margin: 16px 0 0;
+  padding-top: 14px;
+  border-top: 1px solid #e6e8eb;
+  font-size: 13px;
+  color: #475569;
+  font-variant-numeric: tabular-nums;
+  text-align: center;
+}
+
+.steps {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.step {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  font-size: 14px;
+  line-height: 1.4;
+  color: #475569;
+  /* New rows fade in so the list growing doesn't pop. */
+  animation: step_in 0.18s ease-out;
+}
+
+.label {
+  flex: 1 1 auto;
+}
+
+.duration {
+  flex: 0 0 auto;
+  font-variant-numeric: tabular-nums;
+  font-size: 12px;
+  color: #94a3b8;
+}
+
+@keyframes step_in {
+  from { opacity: 0; transform: translateY(2px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+
+.step.completed {
+  color: #0f172a;
+}
+
+.step.error {
+  color: #b91c1c;
+}
+
+/* Status indicator container — fixed size so labels align across rows. */
+.indicator {
+  flex: 0 0 18px;
+  width: 18px;
+  height: 18px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
+/* Pulsing dot for the in-progress step. The dot is a green circle that
+   eases between full and ~30% opacity. We also subtly scale so it reads as
+   "active" not "broken". */
+.dot {
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  background: #22c55e;
+  animation: dot_pulse 1.05s ease-in-out infinite;
+}
+
+@keyframes dot_pulse {
+  0%, 100% { opacity: 1;   transform: scale(1); }
+  50%      { opacity: 0.3; transform: scale(0.78); }
+}
+
+/* Static green dot for completed states (we draw a checkmark on top via
+   the SVG; the dot is the background ring). */
+.check_circle {
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  background: #22c55e;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  /* Brief pop when a step transitions from in_progress -> completed. */
+  animation: check_pop 0.18s ease-out;
+}
+
+@keyframes check_pop {
+  from { transform: scale(0.7); }
+  to   { transform: scale(1); }
+}
+
+.check_glyph {
+  stroke: #ffffff;
+  stroke-width: 2.4;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+  fill: none;
+}
+
+.error_circle {
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  background: #ef4444;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.error_glyph {
+  stroke: #ffffff;
+  stroke-width: 2.4;
+  stroke-linecap: round;
+  fill: none;
+}
+
+.error_message {
+  margin: 16px 0 0;
+  padding: 10px 12px;
+  border-radius: 8px;
+  background: #fef2f2;
+  color: #991b1b;
+  font-size: 13px;
+  line-height: 1.45;
+  border: 1px solid #fee2e2;
+  word-break: break-word;
+}
+
+.actions {
+  margin-top: 18px;
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+}
+
+.close_btn {
+  padding: 6px 14px;
+  border-radius: 6px;
+  border: 1px solid #cbd5e1;
+  background: #ffffff;
+  font-size: 13px;
+  color: #0f172a;
+  cursor: pointer;
+}
+
+.close_btn:hover {
+  background: #f1f5f9;
+}

--- a/frontend/src/common/BacktestLoading/BacktestLoadingOverlay.tsx
+++ b/frontend/src/common/BacktestLoading/BacktestLoadingOverlay.tsx
@@ -1,0 +1,134 @@
+import { createPortal } from "react-dom";
+import styles from "./BacktestLoadingOverlay.module.css";
+import { Step, StreamStatus } from "./types";
+
+interface Props {
+  status: StreamStatus;
+  steps: Step[];
+  error: string | null;
+  totalMs: number | null;
+  // Called when the user dismisses an error overlay. The hook's reset()
+  // is the natural target — clears state and returns the overlay to idle.
+  onClose: () => void;
+}
+
+// BacktestLoadingOverlay renders a fullscreen progress UI for a streaming
+// backtest. Visibility is a *pure function of props* — there's intentionally
+// no local timer state here. The hook owns the post-success "finishing"
+// hold via its own status, which avoids the flicker class of bug where a
+// parent re-render briefly remounts the overlay and resets a local linger.
+//
+// We render via createPortal so the overlay sits above the rest of the SPA
+// without callers needing to lift state or restructure layout.
+export function BacktestLoadingOverlay({
+  status,
+  steps,
+  error,
+  totalMs,
+  onClose,
+}: Props): JSX.Element | null {
+  const visible =
+    status === "streaming" || status === "finishing" || status === "error";
+  if (!visible) return null;
+
+  // SSR guard for any future move off CRA.
+  if (typeof document === "undefined") return null;
+
+  const isError = status === "error";
+  const isFinishing = status === "finishing";
+
+  const titleText = isError
+    ? "Backtest failed"
+    : isFinishing
+      ? "Backtest complete"
+      : "Running backtest";
+
+  // Subtitle is only meaningful during the active run and the error case.
+  // During the finishing hold we move the completion summary to the
+  // bottom of the card, so the top stays clean.
+  const subtitleText = isError
+    ? "We couldn't finish the run. Adjust your inputs and try again."
+    : isFinishing
+      ? null
+      : "Hang tight while we crunch the numbers.";
+
+  const overlay = (
+    <div className={styles.scrim} role="status" aria-live="polite">
+      <div className={styles.card}>
+        <h3 className={styles.title}>{titleText}</h3>
+        {/* Always render the subtitle slot (with a non-breaking space when
+            empty) so the reserved min-height in CSS keeps the card from
+            jumping when we drop the subtitle text during finishing. */}
+        <p className={styles.subtitle}>{subtitleText ?? "\u00A0"}</p>
+
+        <ul className={styles.steps}>
+          {steps.map((step) => (
+            <li
+              key={step.id}
+              className={`${styles.step} ${
+                step.status === "completed"
+                  ? styles.completed
+                  : step.status === "error"
+                    ? styles.error
+                    : ""
+              }`}
+            >
+              <span className={styles.indicator}>
+                {step.status === "in_progress" && <span className={styles.dot} />}
+                {step.status === "completed" && (
+                  <span className={styles.check_circle}>
+                    <svg width="11" height="11" viewBox="0 0 12 12">
+                      <polyline
+                        className={styles.check_glyph}
+                        points="2.5,6.5 5,9 9.5,3.5"
+                      />
+                    </svg>
+                  </span>
+                )}
+                {step.status === "error" && (
+                  <span className={styles.error_circle}>
+                    <svg width="11" height="11" viewBox="0 0 12 12">
+                      <line className={styles.error_glyph} x1="3" y1="3" x2="9" y2="9" />
+                      <line className={styles.error_glyph} x1="9" y1="3" x2="3" y2="9" />
+                    </svg>
+                  </span>
+                )}
+              </span>
+              <span className={styles.label}>{step.label}</span>
+              {step.status === "completed" && step.durationMs !== undefined ? (
+                <span className={styles.duration}>{formatDuration(step.durationMs)}</span>
+              ) : null}
+            </li>
+          ))}
+        </ul>
+
+        {error ? <p className={styles.error_message}>{error}</p> : null}
+
+        {isFinishing ? (
+          <p className={styles.completion_summary}>
+            All done — completed in {formatDuration(totalMs ?? 0)}.
+          </p>
+        ) : null}
+
+        {isError ? (
+          <div className={styles.actions}>
+            <button type="button" className={styles.close_btn} onClick={onClose}>
+              Close
+            </button>
+          </div>
+        ) : null}
+      </div>
+    </div>
+  );
+
+  return createPortal(overlay, document.body);
+}
+
+// formatDuration renders a millisecond count in a human-friendly unit:
+//   < 1s  → "120ms"   (whole milliseconds; sub-second steps are common)
+//   ≥ 1s  → "1.24s"   (two decimals; matches typical perf tooling)
+// Keeping this internal to the overlay file because it's the only consumer.
+function formatDuration(ms: number): string {
+  if (ms < 1000) return `${Math.max(0, Math.round(ms))}ms`;
+  return `${(ms / 1000).toFixed(2)}s`;
+}

--- a/frontend/src/common/BacktestLoading/sse.ts
+++ b/frontend/src/common/BacktestLoading/sse.ts
@@ -1,0 +1,97 @@
+import { BacktestStreamEvent } from "./types";
+
+// parseSSEStream turns a fetch ReadableStream into an async iterable of
+// decoded SSE events. We only support the `data:` line (the BE never emits
+// `event:` or `id:`), and we ignore comment lines (`:` prefix).
+//
+// Note: the WHATWG SSE spec splits frames on a blank line — i.e. \n\n. Some
+// proxies normalize line endings to \r\n; we handle both.
+export async function* parseSSEStream(
+  body: ReadableStream<Uint8Array>,
+  signal?: AbortSignal,
+): AsyncGenerator<BacktestStreamEvent, void, void> {
+  const reader = body.getReader();
+  const decoder = new TextDecoder("utf-8");
+  let buffer = "";
+
+  try {
+    while (true) {
+      if (signal?.aborted) {
+        // Surface as a clean terminal event rather than throwing — callers
+        // already handle "error" events as a normal end-of-stream.
+        return;
+      }
+      const { value, done } = await reader.read();
+      if (done) break;
+      buffer += decoder.decode(value, { stream: true });
+
+      // Split on either Unix or CRLF blank lines so we work behind both
+      // typical reverse proxies and bare Go HTTP servers.
+      let sep: number;
+      while (
+        (sep = indexOfBlankLine(buffer)) !== -1
+      ) {
+        const frame = buffer.slice(0, sep);
+        buffer = buffer.slice(sep + blankLineLength(buffer, sep));
+        const event = decodeFrame(frame);
+        if (event) yield event;
+      }
+    }
+
+    // Drain any trailing frame that didn't end with the standard double
+    // newline (rare, but cheap to handle).
+    const tail = buffer.trim();
+    if (tail) {
+      const event = decodeFrame(tail);
+      if (event) yield event;
+    }
+  } finally {
+    // Releasing the lock is required so the caller can abort or close the
+    // body cleanly. The reader itself can't be reused after this.
+    try {
+      reader.releaseLock();
+    } catch {
+      /* ignore — already released or stream errored */
+    }
+  }
+}
+
+// indexOfBlankLine returns the index of the first character of a blank-line
+// separator (either \n\n or \r\n\r\n) or -1 if not present.
+function indexOfBlankLine(s: string): number {
+  const a = s.indexOf("\n\n");
+  const b = s.indexOf("\r\n\r\n");
+  if (a === -1) return b;
+  if (b === -1) return a;
+  return Math.min(a, b);
+}
+
+function blankLineLength(s: string, idx: number): number {
+  return s.startsWith("\r\n\r\n", idx) ? 4 : 2;
+}
+
+// decodeFrame collapses possibly-multi-line `data:` payloads (per the SSE
+// spec joined with \n) and JSON-decodes them. Comment lines and unknown
+// field names are ignored.
+function decodeFrame(frame: string): BacktestStreamEvent | null {
+  const dataLines: string[] = [];
+  for (const rawLine of frame.split(/\r?\n/)) {
+    if (!rawLine || rawLine.startsWith(":")) continue;
+    const colon = rawLine.indexOf(":");
+    if (colon === -1) continue;
+    const field = rawLine.slice(0, colon);
+    if (field !== "data") continue;
+    // Per spec, a single leading space after the colon is stripped.
+    const value = rawLine.slice(colon + 1).replace(/^ /, "");
+    dataLines.push(value);
+  }
+  if (dataLines.length === 0) return null;
+  const payload = dataLines.join("\n");
+  try {
+    return JSON.parse(payload) as BacktestStreamEvent;
+  } catch {
+    // A malformed frame from the server shouldn't crash the consumer —
+    // skip it and keep reading.
+    return null;
+  }
+}

--- a/frontend/src/common/BacktestLoading/types.ts
+++ b/frontend/src/common/BacktestLoading/types.ts
@@ -1,0 +1,30 @@
+import { BacktestResponse } from "models";
+
+// Wire-format mirror of internal/progress.Event on the backend. If the BE
+// renames any field, this file is the one place to update on the FE.
+export type BacktestStreamEvent =
+  | { type: "step_started"; step: string; label: string }
+  | { type: "step_completed"; step: string; durationMs?: number }
+  | { type: "result"; result: BacktestResponse }
+  | { type: "error"; error: string };
+
+export type StepStatus = "in_progress" | "completed" | "error";
+
+export interface Step {
+  id: string;
+  label: string;
+  status: StepStatus;
+  durationMs?: number;
+}
+
+// Stream lifecycle:
+//   idle       — no run in progress
+//   streaming  — request open, step events flowing
+//   finishing  — terminal `result` received; we deliberately keep the overlay
+//                up briefly so the user actually sees every check turn green
+//                and a "completed in Xs" line. This is a real status, not
+//                local UI state, so the overlay's visibility stays a pure
+//                function of props (no flicker on parent re-renders).
+//   success    — finishing window elapsed, overlay should hide
+//   error      — terminal `error` received OR pre-stream HTTP error
+export type StreamStatus = "idle" | "streaming" | "finishing" | "success" | "error";

--- a/frontend/src/common/BacktestLoading/useBacktestStream.ts
+++ b/frontend/src/common/BacktestLoading/useBacktestStream.ts
@@ -1,0 +1,193 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import { endpoint } from "config";
+import { BacktestRequest, BacktestResponse } from "models";
+import { parseSSEStream } from "./sse";
+import { Step, StreamStatus } from "./types";
+
+export interface UseBacktestStream {
+  status: StreamStatus;
+  steps: Step[];
+  error: string | null;
+  result: BacktestResponse | null;
+  // totalMs is the wall-clock duration from request open to terminal event,
+  // populated on success/error. Used by the overlay to display
+  // "completed in X.Xs".
+  totalMs: number | null;
+  // run kicks off a /backtest/stream request, drives the step state, and
+  // resolves with the final BacktestResponse on a `result` event. It rejects
+  // if the request fails to start (HTTP non-2xx before the stream begins) or
+  // if the stream ends with an `error` event.
+  run: (req: BacktestRequest, accessToken?: string | null) => Promise<BacktestResponse>;
+  reset: () => void;
+}
+
+// FINISHING_HOLD_MS is the grace period the overlay stays up after the
+// terminal `result` event so users actually register the completion
+// summary. 2s is enough time for the eye to scan the per-step durations
+// and the total without dragging.
+const FINISHING_HOLD_MS = 2000;
+
+// useBacktestStream owns the fetch + SSE parsing + per-step UI state. It's
+// intentionally a thin wrapper so the consumer (Form.tsx) can keep calling
+// the same downstream handlers it always has — only the transport changes.
+export function useBacktestStream(): UseBacktestStream {
+  const [status, setStatus] = useState<StreamStatus>("idle");
+  const [steps, setSteps] = useState<Step[]>([]);
+  const [error, setError] = useState<string | null>(null);
+  const [result, setResult] = useState<BacktestResponse | null>(null);
+  const [totalMs, setTotalMs] = useState<number | null>(null);
+
+  // Tracks the AbortController for any in-flight stream so unmount /
+  // re-invocation cancels the previous request. We store it in a ref because
+  // updates inside async code shouldn't trigger renders.
+  const abortRef = useRef<AbortController | null>(null);
+  // Tracks the post-success "finishing" timer so a fast double-run cancels
+  // the prior hold instead of letting it linger into the next stream's UI.
+  const finishingTimerRef = useRef<number | null>(null);
+
+  // Cancel any in-flight request and pending timers on unmount. React
+  // StrictMode in dev will mount → unmount → mount, which could otherwise
+  // leak a fetch or leave a setTimeout firing into a dead component.
+  useEffect(() => {
+    return () => {
+      abortRef.current?.abort();
+      abortRef.current = null;
+      if (finishingTimerRef.current !== null) {
+        window.clearTimeout(finishingTimerRef.current);
+        finishingTimerRef.current = null;
+      }
+    };
+  }, []);
+
+  const reset = useCallback(() => {
+    abortRef.current?.abort();
+    abortRef.current = null;
+    if (finishingTimerRef.current !== null) {
+      window.clearTimeout(finishingTimerRef.current);
+      finishingTimerRef.current = null;
+    }
+    setStatus("idle");
+    setSteps([]);
+    setError(null);
+    setResult(null);
+    setTotalMs(null);
+  }, []);
+
+  const run = useCallback(
+    async (req: BacktestRequest, accessToken?: string | null): Promise<BacktestResponse> => {
+      // Cancel any prior stream before starting a new one. This handles the
+      // double-click case as well as StrictMode re-runs.
+      abortRef.current?.abort();
+      if (finishingTimerRef.current !== null) {
+        window.clearTimeout(finishingTimerRef.current);
+        finishingTimerRef.current = null;
+      }
+      const ctrl = new AbortController();
+      abortRef.current = ctrl;
+
+      const startedAtMs = Date.now();
+
+      setStatus("streaming");
+      setSteps([]);
+      setError(null);
+      setResult(null);
+      setTotalMs(null);
+
+      let response: Response;
+      try {
+        response = await fetch(endpoint + "/backtest/stream", {
+          method: "POST",
+          credentials: "include",
+          headers: {
+            "Content-Type": "application/json",
+            // Bearer is preserved for older direct integrations; the cookie
+            // middleware handles authenticated browser sessions.
+            Authorization: accessToken ? "Bearer " + accessToken : "",
+          },
+          body: JSON.stringify(req),
+          signal: ctrl.signal,
+        });
+      } catch (err) {
+        const msg = (err as Error).message || "network error";
+        setError(msg);
+        setTotalMs(Date.now() - startedAtMs);
+        setStatus("error");
+        throw err;
+      }
+
+      // Pre-stream errors (validation 500 with JSON body) come back the same
+      // way today's /backtest does. Surface them via the hook's error state
+      // *and* throw so the caller can keep its existing inline error UI.
+      if (!response.ok || !response.body) {
+        let msg = `request failed: ${response.status}`;
+        try {
+          const j = (await response.json()) as { error?: string };
+          if (j.error) msg = j.error;
+        } catch {
+          /* response wasn't JSON; fall through with status text */
+        }
+        setError(msg);
+        setTotalMs(Date.now() - startedAtMs);
+        setStatus("error");
+        throw new Error(msg);
+      }
+
+      try {
+        for await (const ev of parseSSEStream(response.body, ctrl.signal)) {
+          if (ev.type === "step_started") {
+            setSteps((prev) => [
+              ...prev,
+              { id: ev.step, label: ev.label, status: "in_progress" },
+            ]);
+          } else if (ev.type === "step_completed") {
+            setSteps((prev) =>
+              prev.map((s) =>
+                s.id === ev.step && s.status === "in_progress"
+                  ? { ...s, status: "completed", durationMs: ev.durationMs }
+                  : s,
+              ),
+            );
+          } else if (ev.type === "result") {
+            setResult(ev.result);
+            setTotalMs(Date.now() - startedAtMs);
+            // Enter the "finishing" hold so the overlay can show every
+            // check + the "completed in" line. We resolve the promise
+            // immediately so the caller's downstream effects (rendering
+            // the chart, etc.) fire in parallel — by the time the hold
+            // elapses, the page underneath is already up to date.
+            setStatus("finishing");
+            finishingTimerRef.current = window.setTimeout(() => {
+              finishingTimerRef.current = null;
+              setStatus("success");
+            }, FINISHING_HOLD_MS);
+            return ev.result;
+          } else if (ev.type === "error") {
+            // Mark the currently-in-progress step (if any) as failed so the
+            // overlay can highlight where things went wrong.
+            setSteps((prev) =>
+              prev.map((s) =>
+                s.status === "in_progress" ? { ...s, status: "error" } : s,
+              ),
+            );
+            setError(ev.error);
+            setTotalMs(Date.now() - startedAtMs);
+            setStatus("error");
+            throw new Error(ev.error);
+          }
+        }
+        // Stream ended without a terminal event. This shouldn't happen
+        // unless the server crashes mid-response, but be defensive.
+        const msg = "backtest stream ended without a result";
+        setError(msg);
+        setTotalMs(Date.now() - startedAtMs);
+        setStatus("error");
+        throw new Error(msg);
+      } finally {
+        if (abortRef.current === ctrl) abortRef.current = null;
+      }
+    },
+    [],
+  );
+
+  return { status, steps, error, result, totalMs, run, reset };
+}

--- a/frontend/src/config.ts
+++ b/frontend/src/config.ts
@@ -1,8 +1,18 @@
 // Single source of truth for the API base URL. Keep this file dependency-free
 // so it can be imported from anywhere (including auth.tsx) without creating
 // circular module loads.
-export const endpoint = process.env.REACT_APP_API_PORT
-  ? `http://localhost:${process.env.REACT_APP_API_PORT}`
-  : process.env.NODE_ENV === "production"
-    ? "https://api.factor.trade"
-    : "http://localhost:3009";
+//
+// Resolution order (highest priority first):
+//   1. REACT_APP_API_URL — full URL override; useful for pointing a local FE
+//      at the production API (e.g. REACT_APP_API_URL=https://api.factor.trade)
+//      so you can exercise real seed data without standing up the local DB.
+//      Production CORS already allows http://localhost:3000 with credentials.
+//   2. REACT_APP_API_PORT — local port override (legacy convenience).
+//   3. NODE_ENV: 'production' → https://api.factor.trade, otherwise localhost:3009.
+export const endpoint = process.env.REACT_APP_API_URL
+  ? process.env.REACT_APP_API_URL.replace(/\/$/, "")
+  : process.env.REACT_APP_API_PORT
+    ? `http://localhost:${process.env.REACT_APP_API_PORT}`
+    : process.env.NODE_ENV === "production"
+      ? "https://api.factor.trade"
+      : "http://localhost:3009";

--- a/frontend/src/pages/Backtest/Form.tsx
+++ b/frontend/src/pages/Backtest/Form.tsx
@@ -14,6 +14,8 @@ import modalsStyle from "common/Modals.module.css";
 import { AppSession as Session } from 'auth';
 import { useAuth } from 'auth';
 import LoginModal from 'common/AuthModals';
+import { BacktestLoadingOverlay } from 'common/BacktestLoading/BacktestLoadingOverlay';
+import { useBacktestStream } from 'common/BacktestLoading/useBacktestStream';
 
 async function getIsBookmarked(session: Session, props: FormViewProps): Promise<any> {
   const bookmarkRequest: BookmarkStrategyRequest = {
@@ -138,8 +140,18 @@ export default function FactorForm({
   const [cash, setCash] = useState(10_000);
   const [names, setNames] = useState<string[]>([...takenNames]);
   const [err, setErr] = useState<string | null>(null);
-  const [loading, setLoading] = useState(false);
   const [assetUniverses, setAssetUniverses] = useState<GetAssetUniversesResponse[]>([]);
+
+  // Streaming backtest progress. The hook drives the fullscreen overlay
+  // (steps + status) and resolves with the final result. We derive the
+  // legacy `loading` flag from it so existing button-disable logic and the
+  // VerboseFormView's post-submit navigate keep working without changes.
+  // `finishing` is the brief post-success hold during which the overlay is
+  // still up — we keep the button disabled across it to prevent a
+  // double-submit landing during the celebratory beat.
+  const backtestStream = useBacktestStream();
+  const loading =
+    backtestStream.status === "streaming" || backtestStream.status === "finishing";
 
   const { session } = useAuth()
 
@@ -170,7 +182,9 @@ export default function FactorForm({
         console.error("Error submitting data:", response.status);
       }
     } catch (error) {
-      setLoading(false)
+      // The legacy code also flipped the backtest loading flag here, but
+      // this is the universe-fetch error path — unrelated to backtest
+      // loading. Just surface the inline error.
       setErr((error as Error).message)
       console.error("Error:", error);
     }
@@ -218,7 +232,6 @@ export default function FactorForm({
       e.preventDefault();
     }
     setErr(null);
-    setLoading(true);
 
     const data: BacktestRequest = {
       factorOptions: {
@@ -234,68 +247,57 @@ export default function FactorForm({
       assetUniverse,
     };
 
-    // this needs to be broken off at some point
+    // useBacktestStream owns the fetch + SSE parsing + per-step UI state.
+    // We catch its rejection here so the overlay can show the error inline
+    // (via its own status) while we *also* surface a brief inline message
+    // for the legacy form path; the overlay supersedes it visually anyway.
+    let result: BacktestResponse;
     try {
-      const response = await fetch(endpoint + "/backtest", {
-        method: "POST",
-        credentials: "include",
-        headers: {
-          "Content-Type": "application/json",
-          "Authorization": session ? "Bearer " + session.access_token : ""
-        },
-        body: JSON.stringify(data)
-      });
-      setLoading(false);
-      if (response.ok) {
-        const result: BacktestResponse = await response.json()
-        if (Object.keys(result.backtestSnapshots).length === 0) {
-          setErr("No backtest results were calculated");
-          return;
-        }
-        jumpToAnchorOnSmallScreen("backtest-chart")
-
-        let newName = data.factorOptions.name;
-        let found = false;
-        let nextNum = 1;
-        names.forEach(n => {
-          if (n.includes(factorName)) {
-            found = true;
-            const match = n.match(/\((\d+)\)/);
-            if (match) {
-              const number = parseInt(match[1], 10);
-              nextNum = Math.max(number + 1, nextNum)
-            }
-          }
-        })
-        if (found) {
-          newName += " (" + nextNum.toString() + ")"
-        }
-
-        setNames([...names, newName])
-        const fd: FactorData = {
-          name: newName,
-          data: result.backtestSnapshots,
-          expression: data.factorOptions.expression
-        } as FactorData;
-
-        appendFactorData(fd)
-        setLatestHoldings(result.latestHoldings);
-        setMetrics({
-          annualizedReturn: result.annualizedReturn,
-          sharpeRatio: result.sharpeRatio,
-          annualizedStandardDeviation: result.annualizedStandardDeviation,
-        })
-        setLastStrategyID(result.strategyID);
-      } else {
-        const j = await response.json()
-        setErr(j.error)
-        console.error("Error submitting data:", response.status);
-      }
+      result = await backtestStream.run(data, session ? session.access_token : null);
     } catch (error) {
-      setLoading(false)
-      setErr((error as Error).message)
+      setErr((error as Error).message);
       console.error("Error:", error);
+      return;
     }
+
+    if (Object.keys(result.backtestSnapshots).length === 0) {
+      setErr("No backtest results were calculated");
+      return;
+    }
+    jumpToAnchorOnSmallScreen("backtest-chart")
+
+    let newName = data.factorOptions.name;
+    let found = false;
+    let nextNum = 1;
+    names.forEach(n => {
+      if (n.includes(factorName)) {
+        found = true;
+        const match = n.match(/\((\d+)\)/);
+        if (match) {
+          const number = parseInt(match[1], 10);
+          nextNum = Math.max(number + 1, nextNum)
+        }
+      }
+    })
+    if (found) {
+      newName += " (" + nextNum.toString() + ")"
+    }
+
+    setNames([...names, newName])
+    const fd: FactorData = {
+      name: newName,
+      data: result.backtestSnapshots,
+      expression: data.factorOptions.expression
+    } as FactorData;
+
+    appendFactorData(fd)
+    setLatestHoldings(result.latestHoldings);
+    setMetrics({
+      annualizedReturn: result.annualizedReturn,
+      sharpeRatio: result.sharpeRatio,
+      annualizedStandardDeviation: result.annualizedStandardDeviation,
+    })
+    setLastStrategyID(result.strategyID);
   };
 
   let rebalanceDuration = 1;
@@ -411,7 +413,19 @@ export default function FactorForm({
 
 
 
-  return fullscreenView ? <VerboseFormView props={props} /> : <ClassicFormView props={props} />
+  // The overlay is a portal-rendered sibling — its placement here is
+  // arbitrary (it ends up on document.body either way). Co-locating it
+  // with the form keeps the streaming state owner and consumer in one place.
+  return <>
+    {fullscreenView ? <VerboseFormView props={props} /> : <ClassicFormView props={props} />}
+    <BacktestLoadingOverlay
+      status={backtestStream.status}
+      steps={backtestStream.steps}
+      error={backtestStream.error}
+      totalMs={backtestStream.totalMs}
+      onClose={backtestStream.reset}
+    />
+  </>
 }
 
 export interface FormViewProps {


### PR DESCRIPTION
## Summary

Replaces the spinner GIF on `/backtest` with a fullscreen progress overlay driven by the new `POST /backtest/stream` endpoint (PR #120).

- New `frontend/src/common/BacktestLoading/` module: `sse.ts` (ReadableStream → AsyncIterable<Event> SSE parser), `useBacktestStream.ts` (fetch + parsing + step state hook), `BacktestLoadingOverlay.tsx` (portal-rendered fullscreen UI with pulsing dot → checkmark transitions, per-step durations, completion summary)
- Both backtest entry points (`Run Backtest` on `/backtest`, clicking a published strategy on `/`) flow through the same `handleSubmit` so both get the overlay automatically
- `config.ts` gains a `REACT_APP_API_URL` override so a local FE can point at the production API for testing against real seed data

## UX behavior

- **During the run**: fullscreen white scrim with a card showing each phase as it streams in. Active step has a pulsing green dot; completed steps get a green checkmark with the duration on the right (`350ms` / `1.24s` style).
- **On completion**: title flips to \"Backtest complete\", a hairline-divided footer appears at the bottom showing \"All done — completed in X.XXs.\". Holds for 2s, then the overlay unmounts and the existing chart / Stats / Invest panel render underneath.
- **On error**: failed step gets a red X, error text shown inline, Close button to dismiss.

## Architecture notes

- Overlay visibility is a pure function of the hook's `status` (`streaming` / `finishing` / `error`). The post-success \"finishing\" hold lives in the hook as a real status, not as local component state — that's intentional. Earlier prototype used a `linger` `useState` inside the overlay and produced a flicker class of bug where parent re-renders during the success transition would briefly remount the overlay and reset the linger.
- Hook owns an `AbortController` so unmount or re-invocation cancels the in-flight fetch cleanly.
- `BacktestResponse` shape on the wire is byte-identical to `/backtest` — only the transport changed, so the existing downstream handlers (`appendFactorData`, `setMetrics`, `setLatestHoldings`, `setLastStrategyID`) keep firing exactly as before.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `CI=false npm run build` succeeds (~+1.84KB gzipped JS)
- [x] Local run end-to-end against prod backend (`REACT_APP_API_URL=https://api.factor.trade npm start`) — happy path, mid-stream error path, validation error path all behave as designed
- [x] Verified the post-success hold actually displays — caught flicker, root-caused, fixed
- [ ] Reviewer eyes on UX feel (2s hold, no green text, completion line at bottom)

## Pointing local FE at prod

```bash
cd frontend
REACT_APP_API_URL=https://api.factor.trade npm start
```

Or persistently — drop into `frontend/.env.local` (gitignored by CRA):

```
REACT_APP_API_URL=https://api.factor.trade
```

Production CORS already allows `http://localhost:3000` with credentials.

Made with [Cursor](https://cursor.com)