### PR TITLE
feat(frontend-v2): landing page + foundation

### DIFF
--- a/frontend-v2/.env.example
+++ b/frontend-v2/.env.example
@@ -1,0 +1,11 @@
+# Backend the frontend hits at runtime. Always-absolute URL.
+# - Empty / unset → falls back to http://localhost:3009 (local Go API).
+# - Absolute URL → used as the base for every apiClient request.
+# Inlined into the bundle at build time. Settable per-process for
+# local dev (e.g. `npm run dev:prod-api`) and per-test for Playwright.
+VITE_API_BASE_URL=
+
+# Port the dev server / preview server binds to. Defaults to 3000 to
+# match the existing Go CORS allowlist. strictPort=true means a taken
+# port fails loudly. Settable per-process for parallel test runs.
+# PORT=3000

--- a/frontend-v2/README.md
+++ b/frontend-v2/README.md
@@ -1,21 +1,45 @@
 # frontend-v2
 
-Greenfield rewrite of the factorbacktest frontend. **Scaffolding only — no implementation yet.**
-
-The legacy app at `frontend/` continues to ship. `frontend-v2/` will replace it page by
-page in subsequent PRs.
+Greenfield rewrite of the factorbacktest frontend. The legacy app at `frontend/` continues
+to ship. `frontend-v2/` is replacing it page by page; see
+[plans/frontend-v2-north-star.md](../plans/frontend-v2-north-star.md) for the long-running
+direction.
 
 ## Stack
 
-- Vite + React + TypeScript
+- Vite + React 19 + TypeScript (strict)
+- Tailwind v4 with tokens defined in `src/styles/globals.css` via `@theme`
+- Geist Sans + Geist Mono via `@fontsource-variable`
+- React Router v7
+- TanStack Query for data fetching, behind a typed `apiClient` (`src/lib/api.ts`)
+- Framer Motion for entrance animations
 - ESLint (flat config) + Prettier
-- The styling system, component library, charting library, data layer, and routing
-  are deliberately **not** wired in yet — each lands with the PR that needs it.
+
+## Configuration
+
+Two env knobs control runtime behavior. Both are respected by `vite dev`,
+`vite preview`, production builds, and Playwright (when it lands).
+
+| Variable            | Purpose                                                                                          | Default                                    |
+| ------------------- | ------------------------------------------------------------------------------------------------ | ------------------------------------------ |
+| `VITE_API_BASE_URL` | Absolute URL of the backend the bundle hits at runtime. Inlined at build time, also read in dev. | `http://localhost:3009` (the local Go API) |
+| `PORT`              | Port the dev / preview server binds to. `strictPort: true` — taken ports fail loudly.            | `3000` (matches the Go CORS allowlist)     |
+
+Sources, in priority order:
+
+1. Per-process env (`VITE_API_BASE_URL=https://api.factor.trade npm run dev`)
+2. `frontend-v2/.env.local` — personal overrides (gitignored)
+3. `frontend-v2/.env` — copy from `.env.example` if you want a local default (gitignored)
+4. Built-in defaults in `src/lib/env.ts`
+
+Both `.env` and `.env.local` are gitignored, so a fresh clone runs against the
+built-in defaults until you opt in.
 
 ## Scripts
 
 ```bash
-npm run dev           # local dev server
+npm run dev           # local FE on :3000 → local Go on :3009
+npm run dev:prod-api  # local FE on :3000 → https://api.factor.trade
 npm run build         # production build into dist/
 npm run preview       # serve the production build locally
 npm run typecheck     # tsc project-references typecheck
@@ -23,6 +47,27 @@ npm run lint          # eslint, fails on any warning (--max-warnings 0)
 npm run lint:fix      # auto-fix what ESLint can
 npm run format        # prettier --write .
 npm run format:check  # prettier --check . (CI uses this)
+```
+
+One-off override pattern:
+
+```bash
+PORT=4000 VITE_API_BASE_URL=https://api.factor.trade npm run dev
+```
+
+For Playwright, mirror the legacy [frontend/playwright.config.ts](../frontend/playwright.config.ts):
+
+```ts
+webServer: [
+  {
+    command: `npm run build && npm run preview`,
+    env: {
+      PORT: String(fePort),
+      VITE_API_BASE_URL: `http://localhost:${bePort}`,
+    },
+    url: `http://localhost:${fePort}`,
+  },
+];
 ```
 
 ## Lint posture
@@ -33,8 +78,10 @@ The full rule set lives in `eslint.config.js`; the headline rules:
   `Form.tsx` and we're not doing that again. Combined with `import-x/no-cycle`,
   this is the structural backbone.
 - **`--max-warnings 0` in CI** — the AI manages this codebase, so warnings are
-  treated as errors at the pipeline boundary. (This replaces the legacy
-  `CI=false` hack that disabled CRA's warnings-as-errors behavior.)
+  treated as errors at the pipeline boundary. (Replaces the legacy `CI=false` hack
+  that disabled CRA's warnings-as-errors behavior.)
+- **`no-restricted-syntax: fetch`** — raw `fetch` is forbidden outside
+  `src/lib/api.ts`. Every call site goes through `apiClient`.
 - **`no-alert`, `no-floating-promises`, `no-misused-promises`,
   `consistent-type-imports`, `react-hooks/exhaustive-deps`** — bug-class rules
   picked specifically to catch patterns the legacy frontend got wrong.

--- a/frontend-v2/eslint.config.js
+++ b/frontend-v2/eslint.config.js
@@ -100,6 +100,25 @@ export default defineConfig([
       'no-console': ['warn', { allow: ['warn', 'error'] }],
       eqeqeq: ['error', 'always'],
       'prefer-const': 'error',
+
+      // Centralize HTTP at src/lib/api.ts (apiClient). Every call to
+      // global `fetch` outside that file would silently bypass our
+      // credentials/JSON/error-shape handling. The override below
+      // re-allows `fetch` inside src/lib/api.ts itself.
+      'no-restricted-syntax': [
+        'error',
+        {
+          selector: "CallExpression[callee.name='fetch']",
+          message: 'Use the apiClient from @/lib/api instead of calling fetch directly.',
+        },
+      ],
+    },
+  },
+  {
+    // The lone exception: src/lib/api.ts *is* the wrapper around fetch.
+    files: ['src/lib/api.ts'],
+    rules: {
+      'no-restricted-syntax': 'off',
     },
   },
 ]);

--- a/frontend-v2/index.html
+++ b/frontend-v2/index.html
@@ -1,10 +1,11 @@
 <!doctype html>
-<html lang="en">
+<html lang="en" class="dark">
   <head>
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>frontend-v2</title>
+    <meta name="color-scheme" content="dark" />
+    <title>factorbacktest</title>
   </head>
   <body>
     <div id="root"></div>

--- a/frontend-v2/package-lock.json
+++ b/frontend-v2/package-lock.json
@@ -8,8 +8,20 @@
       "name": "frontend-v2",
       "version": "0.0.0",
       "dependencies": {
+        "@fontsource-variable/geist": "^5.2.8",
+        "@fontsource-variable/geist-mono": "^5.2.7",
+        "@radix-ui/react-slot": "^1.2.4",
+        "@tailwindcss/vite": "^4.2.4",
+        "@tanstack/react-query": "^5.100.5",
+        "class-variance-authority": "^0.7.1",
+        "clsx": "^2.1.1",
+        "framer-motion": "^12.38.0",
+        "lucide-react": "^1.11.0",
         "react": "^19.2.5",
-        "react-dom": "^19.2.5"
+        "react-dom": "^19.2.5",
+        "react-router": "^7.14.2",
+        "tailwind-merge": "^3.5.0",
+        "tailwindcss": "^4.2.4"
       },
       "devDependencies": {
         "@eslint/js": "^10.0.1",
@@ -295,7 +307,6 @@
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
       "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -307,7 +318,6 @@
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
       "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -318,7 +328,6 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
       "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -453,6 +462,24 @@
         "node": "^20.19.0 || ^22.13.0 || >=24"
       }
     },
+    "node_modules/@fontsource-variable/geist": {
+      "version": "5.2.8",
+      "resolved": "https://registry.npmjs.org/@fontsource-variable/geist/-/geist-5.2.8.tgz",
+      "integrity": "sha512-cJ6m9e+8MQ5dCYJsLylfZrgBh6KkG4bOLckB35Tr9J/EqdkEM6QllH5PxqP1dhTvFup+HtMRPuz9xOjxXJggxw==",
+      "license": "OFL-1.1",
+      "funding": {
+        "url": "https://github.com/sponsors/ayuhito"
+      }
+    },
+    "node_modules/@fontsource-variable/geist-mono": {
+      "version": "5.2.7",
+      "resolved": "https://registry.npmjs.org/@fontsource-variable/geist-mono/-/geist-mono-5.2.7.tgz",
+      "integrity": "sha512-ZKlZ5sjtalb2TwXKs400mAGDlt/+2ENLNySPx0wTz3bP3mWARCsUW+rpxzZc7e05d2qGch70pItt3K4qttbIYA==",
+      "license": "OFL-1.1",
+      "funding": {
+        "url": "https://github.com/sponsors/ayuhito"
+      }
+    },
     "node_modules/@humanfs/core": {
       "version": "0.19.2",
       "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.2.tgz",
@@ -523,7 +550,6 @@
       "version": "0.3.13",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
       "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.0",
@@ -534,7 +560,6 @@
       "version": "2.3.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
       "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/gen-mapping": "^0.3.5",
@@ -545,7 +570,6 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
       "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.0.0"
@@ -555,14 +579,12 @@
       "version": "1.5.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
       "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@jridgewell/trace-mapping": {
       "version": "0.3.31",
       "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
       "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
@@ -573,7 +595,6 @@
       "version": "0.2.12",
       "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-0.2.12.tgz",
       "integrity": "sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ==",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -586,7 +607,6 @@
       "version": "0.127.0",
       "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.127.0.tgz",
       "integrity": "sha512-aIYXQBo4lCbO4z0R3FHeucQHpF46l2LbMdxRvqvuRuW2OxdnSkcng5B8+K12spgLDj93rtN3+J2Vac/TIO+ciQ==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/Boshen"
@@ -599,6 +619,39 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@radix-ui/react-compose-refs": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.1.2.tgz",
+      "integrity": "sha512-z4eqJvfiNnFMHIIvXP3CY57y2WJs5g2v3X0zm9mEJkrkNv4rDxu+sg9Jh8EkXyeqBkB7SOcboo9dMVqhyrACIg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-slot": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.4.tgz",
+      "integrity": "sha512-Jl+bCv8HxKnlTLVrcDE8zTMJ09R9/ukw4qBs/oZClOfoQk/cOTbDn+NceXfV7j09YPVQUryJPHurafcSg6EVKA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@rolldown/binding-android-arm64": {
       "version": "1.0.0-rc.17",
       "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.17.tgz",
@@ -606,7 +659,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -623,7 +675,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -640,7 +691,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -657,7 +707,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -674,7 +723,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -691,7 +739,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -708,7 +755,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -725,7 +771,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -742,7 +787,6 @@
       "cpu": [
         "s390x"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -759,7 +803,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -776,7 +819,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -793,7 +835,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -810,7 +851,6 @@
       "cpu": [
         "wasm32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -826,7 +866,6 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.4.tgz",
       "integrity": "sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -848,7 +887,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -865,7 +903,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -882,11 +919,293 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@tailwindcss/node": {
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/node/-/node-4.2.4.tgz",
+      "integrity": "sha512-Ai7+yQPxz3ddrDQzFfBKdHEVBg0w3Zl83jnjuwxnZOsnH9pGn93QHQtpU0p/8rYWxvbFZHneni6p1BSLK4DkGA==",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/remapping": "^2.3.5",
+        "enhanced-resolve": "^5.19.0",
+        "jiti": "^2.6.1",
+        "lightningcss": "1.32.0",
+        "magic-string": "^0.30.21",
+        "source-map-js": "^1.2.1",
+        "tailwindcss": "4.2.4"
+      }
+    },
+    "node_modules/@tailwindcss/oxide": {
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide/-/oxide-4.2.4.tgz",
+      "integrity": "sha512-9El/iI069DKDSXwTvB9J4BwdO5JhRrOweGaK25taBAvBXyXqJAX+Jqdvs8r8gKpsI/1m0LeJLyQYTf/WLrBT1Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20"
+      },
+      "optionalDependencies": {
+        "@tailwindcss/oxide-android-arm64": "4.2.4",
+        "@tailwindcss/oxide-darwin-arm64": "4.2.4",
+        "@tailwindcss/oxide-darwin-x64": "4.2.4",
+        "@tailwindcss/oxide-freebsd-x64": "4.2.4",
+        "@tailwindcss/oxide-linux-arm-gnueabihf": "4.2.4",
+        "@tailwindcss/oxide-linux-arm64-gnu": "4.2.4",
+        "@tailwindcss/oxide-linux-arm64-musl": "4.2.4",
+        "@tailwindcss/oxide-linux-x64-gnu": "4.2.4",
+        "@tailwindcss/oxide-linux-x64-musl": "4.2.4",
+        "@tailwindcss/oxide-wasm32-wasi": "4.2.4",
+        "@tailwindcss/oxide-win32-arm64-msvc": "4.2.4",
+        "@tailwindcss/oxide-win32-x64-msvc": "4.2.4"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-android-arm64": {
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-android-arm64/-/oxide-android-arm64-4.2.4.tgz",
+      "integrity": "sha512-e7MOr1SAn9U8KlZzPi1ZXGZHeC5anY36qjNwmZv9pOJ8E4Q6jmD1vyEHkQFmNOIN7twGPEMXRHmitN4zCMN03g==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-darwin-arm64": {
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-arm64/-/oxide-darwin-arm64-4.2.4.tgz",
+      "integrity": "sha512-tSC/Kbqpz/5/o/C2sG7QvOxAKqyd10bq+ypZNf+9Fi2TvbVbv1zNpcEptcsU7DPROaSbVgUXmrzKhurFvo5eDg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-darwin-x64": {
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-x64/-/oxide-darwin-x64-4.2.4.tgz",
+      "integrity": "sha512-yPyUXn3yO/ufR6+Kzv0t4fCg2qNr90jxXc5QqBpjlPNd0NqyDXcmQb/6weunH/MEDXW5dhyEi+agTDiqa3WsGg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-freebsd-x64": {
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-freebsd-x64/-/oxide-freebsd-x64-4.2.4.tgz",
+      "integrity": "sha512-BoMIB4vMQtZsXdGLVc2z+P9DbETkiopogfWZKbWwM8b/1Vinbs4YcUwo+kM/KeLkX3Ygrf4/PsRndKaYhS8Eiw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-arm-gnueabihf": {
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm-gnueabihf/-/oxide-linux-arm-gnueabihf-4.2.4.tgz",
+      "integrity": "sha512-7pIHBLTHYRAlS7V22JNuTh33yLH4VElwKtB3bwchK/UaKUPpQ0lPQiOWcbm4V3WP2I6fNIJ23vABIvoy2izdwA==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-arm64-gnu": {
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-gnu/-/oxide-linux-arm64-gnu-4.2.4.tgz",
+      "integrity": "sha512-+E4wxJ0ZGOzSH325reXTWB48l42i93kQqMvDyz5gqfRzRZ7faNhnmvlV4EPGJU3QJM/3Ab5jhJ5pCRUsKn6OQw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-arm64-musl": {
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-musl/-/oxide-linux-arm64-musl-4.2.4.tgz",
+      "integrity": "sha512-bBADEGAbo4ASnppIziaQJelekCxdMaxisrk+fB7Thit72IBnALp9K6ffA2G4ruj90G9XRS2VQ6q2bCKbfFV82g==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-x64-gnu": {
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-gnu/-/oxide-linux-x64-gnu-4.2.4.tgz",
+      "integrity": "sha512-7Mx25E4WTfnht0TVRTyC00j3i0M+EeFe7wguMDTlX4mRxafznw0CA8WJkFjWYH5BlgELd1kSjuU2JiPnNZbJDA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-x64-musl": {
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-musl/-/oxide-linux-x64-musl-4.2.4.tgz",
+      "integrity": "sha512-2wwJRF7nyhOR0hhHoChc04xngV3iS+akccHTGtz965FwF0up4b2lOdo6kI1EbDaEXKgvcrFBYcYQQ/rrnWFVfA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi": {
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-wasm32-wasi/-/oxide-wasm32-wasi-4.2.4.tgz",
+      "integrity": "sha512-FQsqApeor8Fo6gUEklzmaa9994orJZZDBAlQpK2Mq+DslRKFJeD6AjHpBQ0kZFQohVr8o85PPh8eOy86VlSCmw==",
+      "bundleDependencies": [
+        "@napi-rs/wasm-runtime",
+        "@emnapi/core",
+        "@emnapi/runtime",
+        "@tybys/wasm-util",
+        "@emnapi/wasi-threads",
+        "tslib"
+      ],
+      "cpu": [
+        "wasm32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "^1.8.1",
+        "@emnapi/runtime": "^1.8.1",
+        "@emnapi/wasi-threads": "^1.1.0",
+        "@napi-rs/wasm-runtime": "^1.1.1",
+        "@tybys/wasm-util": "^0.10.1",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-win32-arm64-msvc": {
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-arm64-msvc/-/oxide-win32-arm64-msvc-4.2.4.tgz",
+      "integrity": "sha512-L9BXqxC4ToVgwMFqj3pmZRqyHEztulpUJzCxUtLjobMCzTPsGt1Fa9enKbOpY2iIyVtaHNeNvAK8ERP/64sqGQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-win32-x64-msvc": {
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-x64-msvc/-/oxide-win32-x64-msvc-4.2.4.tgz",
+      "integrity": "sha512-ESlKG0EpVJQwRjXDDa9rLvhEAh0mhP1sF7sap9dNZT0yyl9SAG6T7gdP09EH0vIv0UNTlo6jPWyujD6559fZvw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/vite": {
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/vite/-/vite-4.2.4.tgz",
+      "integrity": "sha512-pCvohwOCspk3ZFn6eJzrrX3g4n2JY73H6MmYC87XfGPyTty4YsCjYTMArRZm/zOI8dIt3+EcrLHAFPe5A4bgtw==",
+      "license": "MIT",
+      "dependencies": {
+        "@tailwindcss/node": "4.2.4",
+        "@tailwindcss/oxide": "4.2.4",
+        "tailwindcss": "4.2.4"
+      },
+      "peerDependencies": {
+        "vite": "^5.2.0 || ^6 || ^7 || ^8"
+      }
+    },
+    "node_modules/@tanstack/query-core": {
+      "version": "5.100.5",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.100.5.tgz",
+      "integrity": "sha512-t20KrhKkf0HXzqQkPbJ5erhFesup68BAbwFgYmTrS7bxMF7O5MdmL8jUkik4thsG7Hg00fblz30h6yF1d5TxGg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/react-query": {
+      "version": "5.100.5",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.100.5.tgz",
+      "integrity": "sha512-aNwj1mi2v2bQ9IxkyR1grLOUkv3BYWoykHy9KDyLNbjC3tsahbOHJibK+Wjtr1wRhG59/AvJhiJG5OlthaCgJA==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/query-core": "5.100.5"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19"
+      }
+    },
     "node_modules/@tybys/wasm-util": {
       "version": "0.10.1",
       "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
       "integrity": "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -918,7 +1237,7 @@
       "version": "24.12.2",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-24.12.2.tgz",
       "integrity": "sha512-A1sre26ke7HDIuY/M23nd9gfB+nrmhtYyMINbjI1zHJxYteKR6qSMX56FsmjMcDb3SMcjJg5BiRRgOCC/yBD0g==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~7.16.0"
@@ -928,7 +1247,7 @@
       "version": "19.2.14",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.2.2"
@@ -1600,6 +1919,27 @@
       ],
       "license": "CC-BY-4.0"
     },
+    "node_modules/class-variance-authority": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/class-variance-authority/-/class-variance-authority-0.7.1.tgz",
+      "integrity": "sha512-Ka+9Trutv7G8M6WT6SeiRWz792K5qEqIGEGzXKhAE6xOWAY6pPH8U+9IY3oCMv6kqTmLsv7Xh/2w2RigkePMsg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "clsx": "^2.1.1"
+      },
+      "funding": {
+        "url": "https://polar.sh/cva"
+      }
+    },
+    "node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/comment-parser": {
       "version": "1.4.6",
       "resolved": "https://registry.npmjs.org/comment-parser/-/comment-parser-1.4.6.tgz",
@@ -1616,6 +1956,19 @@
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/cookie": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
+      "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
@@ -1636,7 +1989,7 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/debug": {
@@ -1668,7 +2021,6 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
       "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
-      "dev": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8"
@@ -1680,6 +2032,19 @@
       "integrity": "sha512-4MxfbmNDm+KPh066EZy+eUnkcDPcZ35wNmOWzFuh/ijvHsve6kbLTLURy88uCNK5FbpN+yk2nQY6BYh1GEt+wg==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/enhanced-resolve": {
+      "version": "5.21.0",
+      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.21.0.tgz",
+      "integrity": "sha512-otxSQPw4lkOZWkHpB3zaEQs6gWYEsmX4xQF68ElXC/TWvGxGMSGOvoNbaLXm6/cS/fSfHtsEdw90y20PCd+sCA==",
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.4",
+        "tapable": "^2.3.3"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
     },
     "node_modules/escalade": {
       "version": "3.2.0",
@@ -2041,7 +2406,6 @@
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
       "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12.0.0"
@@ -2106,11 +2470,37 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/framer-motion": {
+      "version": "12.38.0",
+      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-12.38.0.tgz",
+      "integrity": "sha512-rFYkY/pigbcswl1XQSb7q424kSTQ8q6eAC+YUsSKooHQYuLdzdHjrt6uxUC+PRAO++q5IS7+TamgIw1AphxR+g==",
+      "license": "MIT",
+      "dependencies": {
+        "motion-dom": "^12.38.0",
+        "motion-utils": "^12.36.0",
+        "tslib": "^2.4.0"
+      },
+      "peerDependencies": {
+        "@emotion/is-prop-valid": "*",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/is-prop-valid": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -2169,6 +2559,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "license": "ISC"
     },
     "node_modules/hermes-estree": {
       "version": "0.25.1",
@@ -2246,6 +2642,15 @@
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/jiti": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.6.1.tgz",
+      "integrity": "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==",
+      "license": "MIT",
+      "bin": {
+        "jiti": "lib/jiti-cli.mjs"
+      }
     },
     "node_modules/js-tokens": {
       "version": "4.0.0",
@@ -2329,7 +2734,6 @@
       "version": "1.32.0",
       "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
       "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
-      "dev": true,
       "license": "MPL-2.0",
       "dependencies": {
         "detect-libc": "^2.0.3"
@@ -2362,7 +2766,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -2383,7 +2786,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -2404,7 +2806,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -2425,7 +2826,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -2446,7 +2846,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -2467,7 +2866,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -2488,7 +2886,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -2509,7 +2906,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -2530,7 +2926,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -2551,7 +2946,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -2572,7 +2966,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -2612,6 +3005,24 @@
         "yallist": "^3.0.2"
       }
     },
+    "node_modules/lucide-react": {
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-1.11.0.tgz",
+      "integrity": "sha512-UOhjdztXCgdBReRcIhsvz2siIBogfv/lhJEIViCpLt924dO+GDms9T7DNoucI23s6kEPpe988m5N0D2ajnzb2g==",
+      "license": "ISC",
+      "peerDependencies": {
+        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
     "node_modules/minimatch": {
       "version": "10.2.5",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
@@ -2628,6 +3039,21 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/motion-dom": {
+      "version": "12.38.0",
+      "resolved": "https://registry.npmjs.org/motion-dom/-/motion-dom-12.38.0.tgz",
+      "integrity": "sha512-pdkHLD8QYRp8VfiNLb8xIBJis1byQ9gPT3Jnh2jqfFtAsWUA3dEepDlsWe/xMpO8McV+VdpKVcp+E+TGJEtOoA==",
+      "license": "MIT",
+      "dependencies": {
+        "motion-utils": "^12.36.0"
+      }
+    },
+    "node_modules/motion-utils": {
+      "version": "12.36.0",
+      "resolved": "https://registry.npmjs.org/motion-utils/-/motion-utils-12.36.0.tgz",
+      "integrity": "sha512-eHWisygbiwVvf6PZ1vhaHCLamvkSbPIeAYxWUuL3a2PD/TROgE7FvfHWTIH4vMl798QLfMw15nRqIaRDXTlYRg==",
+      "license": "MIT"
+    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
@@ -2639,7 +3065,6 @@
       "version": "3.3.11",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
       "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -2758,14 +3183,12 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
       "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/picomatch": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -2778,7 +3201,6 @@
       "version": "8.5.10",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.10.tgz",
       "integrity": "sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==",
-      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -2860,6 +3282,28 @@
         "react": "^19.2.5"
       }
     },
+    "node_modules/react-router": {
+      "version": "7.14.2",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.14.2.tgz",
+      "integrity": "sha512-yCqNne6I8IB6rVCH7XUvlBK7/QKyqypBFGv+8dj4QBFJiiRX+FG7/nkdAvGElyvVZ/HQP5N19wzteuTARXi5Gw==",
+      "license": "MIT",
+      "dependencies": {
+        "cookie": "^1.0.1",
+        "set-cookie-parser": "^2.6.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/resolve-pkg-maps": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
@@ -2874,7 +3318,6 @@
       "version": "1.0.0-rc.17",
       "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-rc.17.tgz",
       "integrity": "sha512-ZrT53oAKrtA4+YtBWPQbtPOxIbVDbxT0orcYERKd63VJTF13zPcgXTvD4843L8pcsI7M6MErt8QtON6lrB9tyA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@oxc-project/types": "=0.127.0",
@@ -2908,7 +3351,6 @@
       "version": "1.0.0-rc.17",
       "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.17.tgz",
       "integrity": "sha512-n8iosDOt6Ig1UhJ2AYqoIhHWh/isz0xpicHTzpKBeotdVsTEcxsSA/i3EVM7gQAj0rU27OLAxCjzlj15IWY7bg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/scheduler": {
@@ -2929,6 +3371,12 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/set-cookie-parser": {
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.2.tgz",
+      "integrity": "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==",
+      "license": "MIT"
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",
@@ -2957,7 +3405,6 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
       "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
-      "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
@@ -2973,11 +3420,39 @@
         "node": ">=12.0.0"
       }
     },
+    "node_modules/tailwind-merge": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/tailwind-merge/-/tailwind-merge-3.5.0.tgz",
+      "integrity": "sha512-I8K9wewnVDkL1NTGoqWmVEIlUcB9gFriAEkXkfCjX5ib8ezGxtR3xD7iZIxrfArjEsH7F1CHD4RFUtxefdqV/A==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/dcastil"
+      }
+    },
+    "node_modules/tailwindcss": {
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.2.4.tgz",
+      "integrity": "sha512-HhKppgO81FQof5m6TEnuBWCZGgfRAWbaeOaGT00KOy/Pf/j6oUihdvBpA7ltCeAvZpFhW3j0PTclkxsd4IXYDA==",
+      "license": "MIT"
+    },
+    "node_modules/tapable": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.3.3.tgz",
+      "integrity": "sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      }
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.16",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
       "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "fdir": "^6.5.0",
@@ -3007,9 +3482,7 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "dev": true,
-      "license": "0BSD",
-      "optional": true
+      "license": "0BSD"
     },
     "node_modules/type-check": {
       "version": "0.4.0",
@@ -3066,7 +3539,7 @@
       "version": "7.16.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
       "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/unrs-resolver": {
@@ -3149,7 +3622,6 @@
       "version": "8.0.10",
       "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.10.tgz",
       "integrity": "sha512-rZuUu9j6J5uotLDs+cAA4O5H4K1SfPliUlQwqa6YEwSrWDZzP4rhm00oJR5snMewjxF5V/K3D4kctsUTsIU9Mw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "lightningcss": "^1.32.0",

--- a/frontend-v2/package.json
+++ b/frontend-v2/package.json
@@ -5,6 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
+    "dev:prod-api": "VITE_API_BASE_URL=https://api.factor.trade vite",
     "build": "tsc -b && vite build",
     "preview": "vite preview",
     "typecheck": "tsc -b",
@@ -14,8 +15,20 @@
     "format:check": "prettier --check ."
   },
   "dependencies": {
+    "@fontsource-variable/geist": "^5.2.8",
+    "@fontsource-variable/geist-mono": "^5.2.7",
+    "@radix-ui/react-slot": "^1.2.4",
+    "@tailwindcss/vite": "^4.2.4",
+    "@tanstack/react-query": "^5.100.5",
+    "class-variance-authority": "^0.7.1",
+    "clsx": "^2.1.1",
+    "framer-motion": "^12.38.0",
+    "lucide-react": "^1.11.0",
     "react": "^19.2.5",
-    "react-dom": "^19.2.5"
+    "react-dom": "^19.2.5",
+    "react-router": "^7.14.2",
+    "tailwind-merge": "^3.5.0",
+    "tailwindcss": "^4.2.4"
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",

--- a/frontend-v2/src/App.tsx
+++ b/frontend-v2/src/App.tsx
@@ -1,9 +1,19 @@
+import { Route, Routes } from 'react-router';
+
+import { RootLayout } from '@/components/layout/RootLayout';
+import { ComingSoonPage } from '@/pages/ComingSoon';
+import { HomePage } from '@/pages/Home/HomePage';
+
+// Route table. Add new pages here, not in main.tsx.
 function App() {
   return (
-    <main>
-      <h1>frontend-v2</h1>
-      <p>Scaffolding only — no implementation yet.</p>
-    </main>
+    <Routes>
+      <Route element={<RootLayout />}>
+        <Route index element={<HomePage />} />
+        <Route path="backtest" element={<ComingSoonPage pageName="Backtest" />} />
+        <Route path="investments" element={<ComingSoonPage pageName="Investments" />} />
+      </Route>
+    </Routes>
   );
 }
 

--- a/frontend-v2/src/components/layout/Navbar.tsx
+++ b/frontend-v2/src/components/layout/Navbar.tsx
@@ -1,0 +1,30 @@
+import { Link } from 'react-router';
+
+import { Button } from '@/components/ui/button';
+
+// Minimal top nav. Logo on the left, placeholder Sign in on the right.
+// Auth state, sign-in modal, and user menu land with the first
+// protected page (see plans/frontend-v2-north-star.md §4).
+export function Navbar(): React.ReactNode {
+  return (
+    <header className="sticky top-0 z-40 w-full border-b border-border bg-background/80 backdrop-blur">
+      <div className="mx-auto flex h-14 max-w-7xl items-center justify-between px-6">
+        <Link
+          to="/"
+          className="text-sm font-semibold tracking-tight text-foreground hover:text-foreground/90"
+        >
+          factorbacktest
+        </Link>
+        <Button
+          variant="outline"
+          size="sm"
+          // Placeholder — auth wires up in a later PR.
+          disabled
+          aria-label="Sign in (coming soon)"
+        >
+          Sign in
+        </Button>
+      </div>
+    </header>
+  );
+}

--- a/frontend-v2/src/components/layout/RootLayout.tsx
+++ b/frontend-v2/src/components/layout/RootLayout.tsx
@@ -1,0 +1,16 @@
+import { Outlet } from 'react-router';
+
+import { Navbar } from './Navbar';
+
+// Page shell wrapping every route. Top nav + main content area.
+// Future: footer, mobile drawer.
+export function RootLayout(): React.ReactNode {
+  return (
+    <div className="flex min-h-full flex-col bg-background text-foreground">
+      <Navbar />
+      <main className="flex-1">
+        <Outlet />
+      </main>
+    </div>
+  );
+}

--- a/frontend-v2/src/components/motion/CountUpNumber.tsx
+++ b/frontend-v2/src/components/motion/CountUpNumber.tsx
@@ -1,0 +1,43 @@
+import { animate, useMotionValue, useReducedMotion } from 'framer-motion';
+import { useEffect, useState } from 'react';
+
+interface Props {
+  // Final value. When this changes we tween from the prior value.
+  value: number;
+  // Called on each frame to format the displayed string. Letting the
+  // caller own formatting keeps the animation logic decoupled from
+  // unit conventions (percent, ratio, currency).
+  format: (n: number) => string;
+  // ms. Default 600ms matches the rest of the entrance choreography.
+  durationMs?: number;
+}
+
+// Tweens a number from 0 to `value` (and on subsequent updates, from
+// the prior value to the new one) and renders the formatted result on
+// each frame. Honors prefers-reduced-motion by rendering the final
+// value directly with no animation.
+//
+// Used for headline KPIs (annualized return) on landing-page cards.
+// Don't reach for this for every number — overuse looks gimmicky.
+export function CountUpNumber({ value, format, durationMs = 600 }: Props): string {
+  const reduceMotion = useReducedMotion();
+  const motion = useMotionValue(0);
+  // Lazy-init: animated path starts at format(0), reduce-motion path
+  // is short-circuited at render time below.
+  const [display, setDisplay] = useState(() => format(0));
+
+  useEffect(() => {
+    if (reduceMotion) return;
+    // setState happens inside the rAF callback (onUpdate), not
+    // synchronously in the effect body, so the React 19
+    // set-state-in-effect rule is satisfied.
+    const controls = animate(motion, value, {
+      duration: durationMs / 1000,
+      ease: 'easeOut',
+      onUpdate: (latest) => setDisplay(format(latest)),
+    });
+    return () => controls.stop();
+  }, [value, durationMs, format, motion, reduceMotion]);
+
+  return reduceMotion ? format(value) : display;
+}

--- a/frontend-v2/src/components/ui/button.tsx
+++ b/frontend-v2/src/components/ui/button.tsx
@@ -1,0 +1,51 @@
+import { Slot } from '@radix-ui/react-slot';
+import { cva, type VariantProps } from 'class-variance-authority';
+import { type ButtonHTMLAttributes, forwardRef } from 'react';
+
+import { cn } from '@/lib/utils';
+
+// Minimal Button primitive. We hand-rolled instead of running
+// `shadcn add button` because shadcn's v4 templates pull in extra
+// tokens (--ring, --primary-foreground) we haven't modeled yet. The
+// shape and variant API match shadcn closely so a later swap is
+// mechanical.
+const buttonVariants = cva(
+  [
+    'inline-flex items-center justify-center gap-2',
+    'rounded-md font-medium select-none',
+    'transition-colors duration-150 ease-out',
+    'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 focus-visible:ring-offset-background',
+    'disabled:pointer-events-none disabled:opacity-50',
+  ].join(' '),
+  {
+    variants: {
+      variant: {
+        default: 'bg-accent text-accent-foreground hover:bg-accent/90',
+        ghost: 'text-foreground hover:bg-elevated',
+        outline:
+          'border border-border bg-transparent text-foreground hover:bg-elevated hover:border-border-strong',
+      },
+      size: {
+        sm: 'h-8 px-3 text-sm',
+        md: 'h-10 px-4 text-sm',
+        lg: 'h-12 px-6 text-base',
+      },
+    },
+    defaultVariants: { variant: 'default', size: 'md' },
+  },
+);
+
+export type ButtonProps = ButtonHTMLAttributes<HTMLButtonElement> &
+  VariantProps<typeof buttonVariants> & {
+    // When true, render as the child element (Radix Slot pattern) so a
+    // wrapping <Link> doesn't nest <a><button> illegally.
+    asChild?: boolean;
+  };
+
+export const Button = forwardRef<HTMLButtonElement, ButtonProps>(function Button(
+  { className, variant, size, asChild = false, ...props },
+  ref,
+) {
+  const Comp = asChild ? Slot : 'button';
+  return <Comp ref={ref} className={cn(buttonVariants({ variant, size }), className)} {...props} />;
+});

--- a/frontend-v2/src/components/ui/card.tsx
+++ b/frontend-v2/src/components/ui/card.tsx
@@ -1,0 +1,19 @@
+import { type HTMLAttributes, forwardRef } from 'react';
+
+import { cn } from '@/lib/utils';
+
+// Minimal Card primitive. Defaults to bg-card with a 1px hairline
+// border that lifts on hover (set by the consumer when interactive).
+// No drop shadows — flat surfaces are part of the aesthetic.
+export const Card = forwardRef<HTMLDivElement, HTMLAttributes<HTMLDivElement>>(function Card(
+  { className, ...props },
+  ref,
+) {
+  return (
+    <div
+      ref={ref}
+      className={cn('rounded-lg border border-border bg-card', className)}
+      {...props}
+    />
+  );
+});

--- a/frontend-v2/src/lib/api.ts
+++ b/frontend-v2/src/lib/api.ts
@@ -1,0 +1,77 @@
+import { apiBaseUrl } from './env';
+
+// The *only* file allowed to touch global fetch. Everything else goes
+// through apiClient — enforced by ESLint's no-restricted-syntax rule.
+//
+// Why a class with three methods instead of a thin wrapper: keeps the
+// JSON parsing, error surfacing, and credentials behavior in one
+// place; lets us swap transports later (SSE, websockets) without
+// rewriting every call site.
+
+export interface ApiError extends Error {
+  status: number;
+  body: unknown;
+}
+
+class ApiErrorImpl extends Error implements ApiError {
+  status: number;
+  body: unknown;
+
+  constructor(message: string, status: number, body: unknown) {
+    super(message);
+    this.name = 'ApiError';
+    this.status = status;
+    this.body = body;
+  }
+}
+
+async function request<T>(method: string, path: string, body?: unknown): Promise<T> {
+  const url = `${apiBaseUrl}${path}`;
+  const init: RequestInit = {
+    method,
+    // Cookie session is canonical (see internal/auth). Bearer fallback
+    // is gone in v2.
+    credentials: 'include',
+    headers: {
+      Accept: 'application/json',
+      ...(body !== undefined ? { 'Content-Type': 'application/json' } : {}),
+    },
+    ...(body !== undefined ? { body: JSON.stringify(body) } : {}),
+  };
+
+  const res = await fetch(url, init);
+
+  // 204 No Content is valid for some auth endpoints. Return undefined
+  // typed as T — the caller's type contract owns whether that's safe.
+  if (res.status === 204) {
+    return undefined as T;
+  }
+
+  let parsed: unknown = null;
+  const text = await res.text();
+  if (text) {
+    try {
+      parsed = JSON.parse(text);
+    } catch {
+      // Non-JSON body — keep the raw text on the error so we don't
+      // silently lose context.
+      parsed = text;
+    }
+  }
+
+  if (!res.ok) {
+    const message =
+      parsed && typeof parsed === 'object' && 'error' in parsed && typeof parsed.error === 'string'
+        ? parsed.error
+        : `${res.status} ${res.statusText}`;
+    throw new ApiErrorImpl(message, res.status, parsed);
+  }
+
+  return parsed as T;
+}
+
+export const apiClient = {
+  get: <T>(path: string) => request<T>('GET', path),
+  post: <T>(path: string, body?: unknown) => request<T>('POST', path, body),
+  del: <T>(path: string) => request<T>('DELETE', path),
+};

--- a/frontend-v2/src/lib/env.ts
+++ b/frontend-v2/src/lib/env.ts
@@ -1,0 +1,13 @@
+// Single source of truth for runtime config. Always-absolute base URL:
+// the same code path runs in `vite dev`, `vite preview`, production
+// builds, and Playwright. No dev proxy, no NODE_ENV branching.
+//
+// Resolution order:
+//   1. import.meta.env.VITE_API_BASE_URL — inlined at build time, also
+//      readable in dev. Set via .env, .env.local, or per-process env
+//      (e.g. `npm run dev:prod-api`, or Playwright's webServer.env).
+//   2. http://localhost:3009 — the local Go API's default port.
+const raw = (import.meta.env.VITE_API_BASE_URL as string | undefined) ?? '';
+const trimmed = raw.replace(/\/$/, '');
+
+export const apiBaseUrl = trimmed || 'http://localhost:3009';

--- a/frontend-v2/src/lib/format.ts
+++ b/frontend-v2/src/lib/format.ts
@@ -1,0 +1,43 @@
+// Single source of truth for tabular display. Every percent / number /
+// ratio in the UI flows through here so n/a fallbacks and decimal
+// places stay consistent across cards, tables, and charts.
+//
+// All functions accept `null | undefined` and return the same `'n/a'`
+// string. Callers should *not* re-implement this; doing so silently
+// diverges from how empty values look elsewhere.
+
+const N_A = 'n/a';
+
+export function formatPercent(value: number | null | undefined, fractionDigits = 2): string {
+  if (value === null || value === undefined || Number.isNaN(value)) return N_A;
+  return `${(value * 100).toFixed(fractionDigits)}%`;
+}
+
+export function formatSharpe(value: number | null | undefined, fractionDigits = 2): string {
+  if (value === null || value === undefined || Number.isNaN(value)) return N_A;
+  return value.toFixed(fractionDigits);
+}
+
+export function formatNumber(
+  value: number | null | undefined,
+  options?: Intl.NumberFormatOptions,
+): string {
+  if (value === null || value === undefined || Number.isNaN(value)) return N_A;
+  return new Intl.NumberFormat('en-US', options).format(value);
+}
+
+// Pretty-print rebalance interval values that come back from the API
+// in lowercase singular ('monthly', 'weekly', etc).
+export function formatRebalanceInterval(interval: string): string {
+  if (!interval) return N_A;
+  return interval.charAt(0).toUpperCase() + interval.slice(1);
+}
+
+// Sign-aware delta pill text: '+12.40%' for positive, '-3.20%' for
+// negative, with the same n/a fallback. Sign is explicit so the eye
+// can register direction without scanning color.
+export function formatDelta(value: number | null | undefined, fractionDigits = 2): string {
+  if (value === null || value === undefined || Number.isNaN(value)) return N_A;
+  const pct = (value * 100).toFixed(fractionDigits);
+  return value >= 0 ? `+${pct}%` : `${pct}%`;
+}

--- a/frontend-v2/src/lib/theme.tsx
+++ b/frontend-v2/src/lib/theme.tsx
@@ -1,0 +1,53 @@
+import { createContext, useContext, useEffect, useState, type ReactNode } from 'react';
+
+// Minimal theme provider: dark-default, persisted to localStorage.
+// Light theme is wired through but unstyled — landing in a follow-up
+// PR once the dark version is locked. Until then, calling
+// `setTheme('light')` produces a flash of unstyled cards.
+type Theme = 'dark' | 'light';
+
+interface ThemeContextValue {
+  theme: Theme;
+  setTheme: (next: Theme) => void;
+  toggleTheme: () => void;
+}
+
+const STORAGE_KEY = 'frontend-v2.theme';
+const DEFAULT_THEME: Theme = 'dark';
+
+const ThemeContext = createContext<ThemeContextValue | null>(null);
+
+function readStored(): Theme {
+  if (typeof window === 'undefined') return DEFAULT_THEME;
+  const v = window.localStorage.getItem(STORAGE_KEY);
+  return v === 'light' || v === 'dark' ? v : DEFAULT_THEME;
+}
+
+export function ThemeProvider({ children }: { children: ReactNode }): ReactNode {
+  const [theme, setThemeState] = useState<Theme>(readStored);
+
+  useEffect(() => {
+    const root = document.documentElement;
+    root.classList.toggle('dark', theme === 'dark');
+    root.style.colorScheme = theme;
+    window.localStorage.setItem(STORAGE_KEY, theme);
+  }, [theme]);
+
+  const value: ThemeContextValue = {
+    theme,
+    setTheme: setThemeState,
+    toggleTheme: () => setThemeState((prev) => (prev === 'dark' ? 'light' : 'dark')),
+  };
+
+  return <ThemeContext.Provider value={value}>{children}</ThemeContext.Provider>;
+}
+
+// Co-located with the provider intentionally — keeping the hook in a
+// separate file would buy us Fast Refresh for theme.tsx but cost a
+// file split that doesn't help readers.
+// eslint-disable-next-line react-refresh/only-export-components
+export function useTheme(): ThemeContextValue {
+  const ctx = useContext(ThemeContext);
+  if (!ctx) throw new Error('useTheme must be used within <ThemeProvider>');
+  return ctx;
+}

--- a/frontend-v2/src/lib/utils.ts
+++ b/frontend-v2/src/lib/utils.ts
@@ -1,0 +1,9 @@
+import { clsx, type ClassValue } from 'clsx';
+import { twMerge } from 'tailwind-merge';
+
+// shadcn convention: single helper that handles conditional classnames
+// (clsx) plus deduping conflicting Tailwind utilities (tailwind-merge).
+// Used by every component that composes classes.
+export function cn(...inputs: ClassValue[]): string {
+  return twMerge(clsx(inputs));
+}

--- a/frontend-v2/src/main.tsx
+++ b/frontend-v2/src/main.tsx
@@ -1,13 +1,37 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
+import { BrowserRouter } from 'react-router';
 
 import App from './App.tsx';
+import { ThemeProvider } from '@/lib/theme';
+
+import './styles/globals.css';
+
+// One QueryClient per page load. 60s staleTime is a sane default for
+// rarely-changing reference data; per-query overrides go on the
+// useQuery call.
+const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      staleTime: 60_000,
+      retry: 1,
+      refetchOnWindowFocus: false,
+    },
+  },
+});
 
 const rootEl = document.getElementById('root');
 if (!rootEl) throw new Error('#root not found');
 
 createRoot(rootEl).render(
   <StrictMode>
-    <App />
+    <ThemeProvider>
+      <QueryClientProvider client={queryClient}>
+        <BrowserRouter>
+          <App />
+        </BrowserRouter>
+      </QueryClientProvider>
+    </ThemeProvider>
   </StrictMode>,
 );

--- a/frontend-v2/src/pages/ComingSoon.tsx
+++ b/frontend-v2/src/pages/ComingSoon.tsx
@@ -1,0 +1,16 @@
+// Placeholder for /backtest and /investments so the landing-page CTA
+// and nav links don't 404 during the rewrite. Each lands as a real
+// page in a subsequent PR.
+export function ComingSoonPage({ pageName }: { pageName: string }): React.ReactNode {
+  return (
+    <div className="mx-auto flex max-w-7xl flex-col items-center justify-center px-6 py-32 text-center">
+      <p className="text-xs font-medium uppercase tracking-widest text-subtle-foreground">
+        Coming soon
+      </p>
+      <h1 className="mt-4 text-3xl font-semibold tracking-tight text-foreground">{pageName}</h1>
+      <p className="mt-3 max-w-md text-sm text-muted-foreground">
+        This page is part of the frontend-v2 rewrite and is being built in a follow-up PR.
+      </p>
+    </div>
+  );
+}

--- a/frontend-v2/src/pages/Home/Hero.tsx
+++ b/frontend-v2/src/pages/Home/Hero.tsx
@@ -1,0 +1,36 @@
+import { useNavigate } from 'react-router';
+
+import { Button } from '@/components/ui/button';
+
+// Hero section above the strategy grid. Title, subtitle, primary CTA
+// to the backtest builder. No marketing fluff — the product is the
+// chart.
+export function Hero(): React.ReactNode {
+  const navigate = useNavigate();
+  return (
+    <section className="mx-auto max-w-7xl px-6 pt-16 pb-12">
+      <div className="flex flex-col items-start gap-6">
+        <div>
+          <h1 className="text-4xl font-semibold tracking-tight text-foreground sm:text-5xl">
+            Factor Backtest
+          </h1>
+          <p className="mt-3 max-w-xl text-base text-muted-foreground">
+            Create and backtest factor-based investment strategies. Compose factors, simulate
+            against historical asset universes, and evaluate risk-adjusted performance.
+          </p>
+        </div>
+        <Button
+          size="lg"
+          onClick={() => {
+            // navigate returns a Promise in react-router v7; void it so
+            // ESLint's no-misused-promises stays happy and so an
+            // accidental navigation rejection doesn't surface unhandled.
+            void navigate('/backtest');
+          }}
+        >
+          Create Strategy
+        </Button>
+      </div>
+    </section>
+  );
+}

--- a/frontend-v2/src/pages/Home/HomePage.tsx
+++ b/frontend-v2/src/pages/Home/HomePage.tsx
@@ -1,0 +1,59 @@
+import { useQuery } from '@tanstack/react-query';
+
+import { Hero } from './Hero';
+import { StrategyGrid } from './StrategyGrid';
+import { apiClient } from '@/lib/api';
+import type { PublishedStrategy } from '@/types/api';
+
+// Top-level landing page. Owns the data fetch; renders Hero +
+// StrategyGrid with explicit loading / error / success states.
+export function HomePage(): React.ReactNode {
+  const { data, isLoading, isError, error } = useQuery({
+    queryKey: ['publishedStrategies'],
+    queryFn: () => apiClient.get<PublishedStrategy[]>('/publishedStrategies'),
+  });
+
+  return (
+    <>
+      <Hero />
+      <section className="mx-auto max-w-7xl px-6 pb-24">
+        <header className="mb-6">
+          <h2 className="text-lg font-semibold tracking-tight text-foreground">
+            Published strategies
+          </h2>
+          <p className="mt-1 text-sm text-muted-foreground">
+            Browse community strategies, click through to see the full backtest.
+          </p>
+        </header>
+
+        {isLoading && <SkeletonGrid />}
+        {isError && (
+          <div className="rounded-lg border border-border bg-card p-6">
+            <p className="text-sm font-medium text-loss">Failed to load strategies</p>
+            <p className="mt-1 text-sm text-muted-foreground">
+              {error instanceof Error ? error.message : 'Unknown error'}
+            </p>
+          </div>
+        )}
+        {data && <StrategyGrid strategies={data} />}
+      </section>
+    </>
+  );
+}
+
+// Skeleton matches the grid shape so the layout doesn't jump when the
+// real data lands. Six placeholders covers two rows on the common
+// desktop breakpoint.
+function SkeletonGrid(): React.ReactNode {
+  return (
+    <div className="grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-3">
+      {Array.from({ length: 6 }).map((_, i) => (
+        <div
+          key={i}
+          className="h-64 animate-pulse rounded-lg border border-border bg-card/60"
+          aria-hidden
+        />
+      ))}
+    </div>
+  );
+}

--- a/frontend-v2/src/pages/Home/StrategyCard.tsx
+++ b/frontend-v2/src/pages/Home/StrategyCard.tsx
@@ -1,0 +1,143 @@
+import { motion } from 'framer-motion';
+import { useNavigate } from 'react-router';
+
+import { CountUpNumber } from '@/components/motion/CountUpNumber';
+import { Card } from '@/components/ui/card';
+import { formatDelta, formatPercent, formatRebalanceInterval, formatSharpe } from '@/lib/format';
+import { cn } from '@/lib/utils';
+import type { PublishedStrategy } from '@/types/api';
+
+// Card composition (top → bottom):
+//   1. header: name (large) + description (clamped)
+//   2. headline KPI: annualized return — count-up tween, gain/loss color
+//   3. delta pill: same value as a tinted +/- chip for at-a-glance scan
+//   4. secondary KPIs: Sharpe + volatility, right-aligned, tabular-mono
+//   5. meta chips: rebalance / universe / num assets — small uppercase
+// Hover: border lifts to border-strong, slight scale. Click → backtest.
+export function StrategyCard({
+  strategy,
+  index,
+}: {
+  strategy: PublishedStrategy;
+  // Used to stagger the entrance animation in the grid. Caller passes
+  // the array index; we don't reach for siblings.
+  index: number;
+}): React.ReactNode {
+  const navigate = useNavigate();
+  const ret = strategy.annualizedReturn;
+  // Color on the headline number tracks sign vs. zero baseline. Null
+  // values stay neutral (foreground).
+  const isPositive = ret !== null && ret >= 0;
+  const isNegative = ret !== null && ret < 0;
+
+  return (
+    <motion.div
+      initial={{ opacity: 0, y: 8 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{
+        // Staggered entrance — 40ms between cards mirrors Linear/Vercel
+        // dashboard reveals. Cap to keep late cards from feeling lazy.
+        delay: Math.min(index * 0.04, 0.4),
+        duration: 0.25,
+        ease: 'easeOut',
+      }}
+    >
+      <Card
+        role="button"
+        tabIndex={0}
+        onClick={() => {
+          // navigate returns a Promise in react-router v7; we don't
+          // care about the result here.
+          void navigate(`/backtest?id=${strategy.strategyID}`);
+        }}
+        onKeyDown={(e) => {
+          if (e.key === 'Enter' || e.key === ' ') {
+            e.preventDefault();
+            void navigate(`/backtest?id=${strategy.strategyID}`);
+          }
+        }}
+        className={cn(
+          'group flex h-full cursor-pointer flex-col gap-5 p-5',
+          'transition-[border-color,transform,background-color] duration-150 ease-out',
+          'hover:scale-[1.005] hover:border-border-strong hover:bg-card/60',
+        )}
+      >
+        {/* Header */}
+        <div>
+          <h3 className="text-base font-semibold tracking-tight text-foreground">
+            {strategy.strategyName}
+          </h3>
+          <p className="mt-1 line-clamp-2 min-h-[2.5rem] text-sm text-muted-foreground">
+            {strategy.description ?? 'No description provided.'}
+          </p>
+        </div>
+
+        {/* Headline KPI: annualized return. Count-up on mount; color
+            tracks sign. Tabular-mono for the digits. */}
+        <div className="flex items-end justify-between gap-4">
+          <div>
+            <p className="text-xs uppercase tracking-widest text-subtle-foreground">
+              Annualized Return
+            </p>
+            <p
+              className={cn(
+                'mt-1 font-mono text-3xl font-semibold tracking-tight',
+                isPositive && 'text-gain',
+                isNegative && 'text-loss',
+                ret === null && 'text-foreground',
+              )}
+            >
+              {ret === null ? (
+                'n/a'
+              ) : (
+                <CountUpNumber value={ret} format={(n) => formatPercent(n)} />
+              )}
+            </p>
+          </div>
+          {ret !== null && (
+            <span
+              className={cn(
+                'inline-flex h-7 items-center rounded-full px-2.5 font-mono text-xs font-medium',
+                isPositive && 'bg-gain/15 text-gain',
+                isNegative && 'bg-loss/15 text-loss',
+              )}
+            >
+              {formatDelta(ret)}
+            </span>
+          )}
+        </div>
+
+        {/* Secondary KPIs. Right-aligned numbers in tabular-mono. */}
+        <dl className="grid grid-cols-2 gap-4 border-t border-border pt-4">
+          <div>
+            <dt className="text-xs uppercase tracking-widest text-subtle-foreground">Sharpe</dt>
+            <dd className="mt-1 font-mono text-sm font-medium text-foreground">
+              {formatSharpe(strategy.sharpeRatio)}
+            </dd>
+          </div>
+          <div className="text-right">
+            <dt className="text-xs uppercase tracking-widest text-subtle-foreground">Volatility</dt>
+            <dd className="mt-1 font-mono text-sm font-medium text-foreground">
+              {formatPercent(strategy.annualizedStandardDeviation)}
+            </dd>
+          </div>
+        </dl>
+
+        {/* Meta chips — rebalance / universe / num assets. */}
+        <div className="flex flex-wrap items-center gap-2">
+          <Chip>{formatRebalanceInterval(strategy.rebalanceInterval)}</Chip>
+          <Chip>{strategy.assetUniverse}</Chip>
+          <Chip>{strategy.numAssets} assets</Chip>
+        </div>
+      </Card>
+    </motion.div>
+  );
+}
+
+function Chip({ children }: { children: React.ReactNode }): React.ReactNode {
+  return (
+    <span className="inline-flex items-center rounded-md border border-border bg-elevated px-2 py-0.5 text-[10px] font-medium uppercase tracking-widest text-muted-foreground">
+      {children}
+    </span>
+  );
+}

--- a/frontend-v2/src/pages/Home/StrategyGrid.tsx
+++ b/frontend-v2/src/pages/Home/StrategyGrid.tsx
@@ -1,0 +1,25 @@
+import { StrategyCard } from './StrategyCard';
+import type { PublishedStrategy } from '@/types/api';
+
+// Responsive grid of strategy cards. Stagger animation lives on the
+// individual cards (using their array index) so reordering feels
+// natural without orchestration here.
+export function StrategyGrid({ strategies }: { strategies: PublishedStrategy[] }): React.ReactNode {
+  if (strategies.length === 0) {
+    return (
+      <div className="rounded-lg border border-dashed border-border bg-card/40 p-12 text-center">
+        <p className="text-sm text-muted-foreground">
+          No published strategies yet. Create the first one.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-3">
+      {strategies.map((s, i) => (
+        <StrategyCard key={s.strategyID} strategy={s} index={i} />
+      ))}
+    </div>
+  );
+}

--- a/frontend-v2/src/styles/globals.css
+++ b/frontend-v2/src/styles/globals.css
@@ -1,0 +1,95 @@
+@import 'tailwindcss';
+
+/* Geist variable fonts. The packages register CSS @font-face rules and
+ * expose the families as 'Geist Variable' / 'Geist Mono Variable'. We
+ * alias them in @theme below so utilities like font-sans / font-mono
+ * resolve to Geist by default. */
+@import '@fontsource-variable/geist';
+@import '@fontsource-variable/geist-mono';
+
+/* Design tokens — single source of truth, mirrors plans/frontend-v2-north-star.md §2.
+ * Tailwind v4 turns each --color-* / --font-* into a utility automatically
+ * (e.g. --color-card → bg-card, text-card; --font-mono → font-mono). */
+@theme {
+  /* Surfaces */
+  --color-background: #0a0a0b;
+  --color-card: #111214;
+  --color-elevated: #1a1b1f;
+
+  /* Borders — semantic names track shadcn-v4 conventions so future
+   * shadcn primitives drop in without renaming. */
+  --color-border: rgba(255, 255, 255, 0.06);
+  --color-border-strong: rgba(255, 255, 255, 0.1);
+
+  /* Text */
+  --color-foreground: #fafafa;
+  --color-muted-foreground: #a1a1aa;
+  --color-subtle-foreground: #71717a;
+
+  /* Semantic colors. Gain/loss are emerald-500 / red-500; their
+   * matching gradient stops live in the StrategyCard component. */
+  --color-gain: #10b981;
+  --color-loss: #ef4444;
+  --color-accent: #3b82f6;
+  --color-accent-foreground: #ffffff;
+  --color-warn: #f59e0b;
+
+  /* Type. Geist Sans for UI, Geist Mono for every number / table /
+   * tooltip / axis label — see body { font-variant-numeric } below. */
+  --font-sans:
+    'Geist Variable', ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI',
+    Roboto, 'Helvetica Neue', Arial, sans-serif;
+  --font-mono:
+    'Geist Mono Variable', ui-monospace, SFMono-Regular, 'SF Mono', Menlo, Consolas,
+    'Liberation Mono', monospace;
+
+  /* Radii — small + tight, no chunky cards. */
+  --radius-sm: 0.25rem;
+  --radius-md: 0.5rem;
+  --radius-lg: 0.75rem;
+}
+
+/* Base resets. The single biggest "fintech vs homework project" lever:
+ * tabular-nums + slashed-zero on every number by default. We turn it
+ * on globally and let prose blocks opt out if needed. */
+@layer base {
+  html,
+  body,
+  #root {
+    height: 100%;
+  }
+
+  body {
+    background-color: var(--color-background);
+    color: var(--color-foreground);
+    font-family: var(--font-sans);
+    font-feature-settings: 'cv11', 'ss01';
+    font-variant-numeric: tabular-nums slashed-zero;
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
+  }
+
+  /* Numbers, tables, axis labels, tooltips. Use `.font-mono` or apply
+   * directly. */
+  code,
+  kbd,
+  samp,
+  pre,
+  .tabular {
+    font-family: var(--font-mono);
+    font-variant-numeric: tabular-nums slashed-zero;
+  }
+
+  /* Focus ring — keep visible but subtle. */
+  :focus-visible {
+    outline: 2px solid var(--color-accent);
+    outline-offset: 2px;
+  }
+}
+
+/* Dark is the default and the only theme implemented. The .dark class
+ * on <html> is set by the ThemeProvider so future light-mode work is
+ * additive, not a swap. */
+:root {
+  color-scheme: dark;
+}

--- a/frontend-v2/src/types/api.ts
+++ b/frontend-v2/src/types/api.ts
@@ -1,0 +1,23 @@
+// Hand-ported API contract. Source: api/get_published_strategies.resolver.go
+// (Go server is the source of truth; we mirror what it actually emits).
+//
+// Other types port lazily as PRs need them — codegen from the Go API
+// is a future concern (see plans/frontend-v2-north-star.md §8).
+
+export interface PublishedStrategy {
+  strategyID: string;
+  strategyName: string;
+  rebalanceInterval: string;
+  // ISO-8601 string, NOT a Date. The legacy frontend's `Date` typing
+  // here was wrong (Go marshals time.Time → string).
+  createdAt: string;
+  factorExpression: string;
+  numAssets: number;
+  assetUniverse: string;
+  // Optional because GetLatestPublishedRun can return nil for
+  // strategies that have no runs yet.
+  sharpeRatio: number | null;
+  annualizedReturn: number | null;
+  annualizedStandardDeviation: number | null;
+  description: string | null;
+}

--- a/frontend-v2/tsconfig.app.json
+++ b/frontend-v2/tsconfig.app.json
@@ -15,6 +15,14 @@
     "noEmit": true,
     "jsx": "react-jsx",
 
+    /* Path aliases — `@/*` maps to `src/*`. Both the bundler (via
+       vite-tsconfig-paths) and tsc (via this config) read from here.
+       baseUrl is deprecated in TS 6+, so paths are written relative
+       to the tsconfig instead. */
+    "paths": {
+      "@/*": ["./src/*"]
+    },
+
     /* Strictness */
     "strict": true,
     "noImplicitOverride": true,

--- a/frontend-v2/vite.config.ts
+++ b/frontend-v2/vite.config.ts
@@ -1,7 +1,25 @@
+import tailwindcss from '@tailwindcss/vite';
 import react from '@vitejs/plugin-react';
 import { defineConfig } from 'vite';
 
+// Single source of truth for runtime config. Both `vite` (dev) and
+// `vite preview` (production-realistic local server, also used by
+// Playwright) bind to PORT with strictPort:true so a taken port fails
+// loudly instead of silently incrementing — Playwright relies on the
+// port it picked actually being the port the server bound to.
+//
+// The backend URL is *not* read here. It's read by the running app via
+// import.meta.env.VITE_API_BASE_URL so the same bundle can be pointed
+// at any backend without rebuilding.
+const port = Number(process.env.PORT ?? 3000);
+
 // https://vite.dev/config/
 export default defineConfig({
-  plugins: [react()],
+  plugins: [react(), tailwindcss()],
+  // Vite 8 reads `paths` from tsconfig.app.json natively — no plugin
+  // needed. Both tsc and the bundler resolve `@/*` from the same
+  // source.
+  resolve: { tsconfigPaths: true },
+  server: { port, strictPort: true, host: true },
+  preview: { port, strictPort: true, host: true },
 });


### PR DESCRIPTION
## Summary

PR 2 of the rewrite. Replaces legacy `frontend/src/pages/Home/Home.tsx` with a redesigned, animated landing page and lays down only the minimum foundation that page needs (Tailwind v4 + tokens, fonts, theme, router, TanStack Query, typed apiClient). No backend changes, no auth wiring, no production deploy plumbing — local-dev only.

Plan: `plans/frontend-v2-north-star.md` for the long-running direction.

## Foundation

| Concern | Choice |
| --- | --- |
| Styling | Tailwind v4, tokens in `src/styles/globals.css` via `@theme` |
| Fonts | Geist Sans + Geist Mono via `@fontsource-variable`; `tabular-nums slashed-zero` set globally |
| Components | Hand-rolled `Button` + `Card` (shadcn-shaped API) |
| Theme | Minimal provider — dark default, persisted to localStorage |
| Router | React Router v7 + `RootLayout` + `Navbar`; placeholder `/backtest` and `/investments` so CTAs don't 404 |
| Data | TanStack Query, 60s staleTime |
| HTTP | Typed `apiClient` in `src/lib/api.ts` — the **only** file allowed to call global \`fetch\`, enforced by ESLint |
| Aliases | `@/*` -> `src/*`, single source in `tsconfig.app.json`; Vite 8 reads natively |

## Runtime configuration (Playwright-ready)

Replaces the legacy CRA \`REACT_APP_*\` hacks with two clean env knobs:

- **\`PORT\`** — read in \`vite.config.ts\` with \`strictPort: true\` so a taken port fails loudly. Default \`3000\`.
- **\`VITE_API_BASE_URL\`** — always-absolute backend URL. Inlined at build time, also read in dev. Same code path in dev, \`vite preview\`, prod, and Playwright (no dev proxy to diverge).

Scripts:

\`\`\`bash
npm run dev           # FE :3000 -> Go :3009
npm run dev:prod-api  # FE :3000 -> https://api.factor.trade
npm run build
npm run preview
\`\`\`

One-off override pattern (also what Playwright will use):

\`\`\`bash
PORT=4000 VITE_API_BASE_URL=http://localhost:9999 npm run preview
\`\`\`

README has a worked example of the future Playwright \`webServer\` block.

## Lint update

- Added \`no-restricted-syntax\` rule banning raw \`fetch\` outside \`src/lib/api.ts\` (with per-file override for the apiClient itself).

## Landing page

\`src/pages/Home/HomePage.tsx\` — owns the data fetch (\`useQuery\` -> \`/publishedStrategies\`), renders Hero + StrategyGrid with explicit loading / empty / error / skeleton states.

\`StrategyCard\`:
- header: name + clamped description
- headline annualized return as a 32px tabular-mono \`CountUpNumber\` tween in gain/loss color
- sign-aware delta pill (\`+12.40%\` / \`-3.20%\`)
- Sharpe + volatility row, right-aligned, tabular-mono
- meta chips for rebalance / universe / num assets
- hover: border lifts to \`border-strong\`, slight scale; click navigates to \`/backtest?id=<id>\`
- \`prefers-reduced-motion\` honored on the count-up

\`StrategyGrid\`: responsive (1 / 2 / 3 cols), index-based stagger fade-in.

Uses only data \`GET /publishedStrategies\` already returns. Real animated equity-curve sparklines per card wait for a future PR that adds the equity-curve endpoint.

## Test plan

Locally with the Go API on \`:3009\` and seed data:

- [x] \`npm run typecheck\` — green
- [x] \`npm run lint\` — green (\`--max-warnings 0\`)
- [x] \`npm run format:check\` — green
- [x] \`npm run build\` — green; 431 KB JS / 137 KB gzip + ~115 KB of variable Geist woff2; 141ms
- [x] ESLint rejects raw \`fetch\` outside \`src/lib/api.ts\` (verified with a temporary canary)
- [x] \`VITE_API_BASE_URL=https://example.test npm run build\` inlines the URL into the bundle
- [x] \`PORT=4242 npm run preview\` binds to \`:4242\` and serves the built page (verified via lsof + curl)
- [ ] CI pipeline passes on this PR
- [ ] Reviewer: clone, \`npm install\`, \`npm run dev\`, open \`http://localhost:3000\`, click through a strategy card to \`/backtest?id=...\`

## Out of scope (deferred to later PRs)

- Auth context, login modal, sign-out — first protected page picks this up
- Tremor — shadcn \`Card\` is enough for landing
- TradingView Lightweight Charts — lands with the backtest read view
- Real per-card sparkline (needs an equity-curve endpoint)
- Production deploy / S3+CloudFront for \`frontend-v2\`
- Vitest / Playwright tests

Made with [Cursor](https://cursor.com)