### PR TITLE
feat(db): expire factor_score cache rows after 2 weeks

### DIFF
--- a/migrations/000058_factor_score_ttl.down.sql
+++ b/migrations/000058_factor_score_ttl.down.sql
@@ -1,0 +1,1 @@
+SELECT cron.unschedule('expire-factor-scores');

--- a/migrations/000058_factor_score_ttl.up.sql
+++ b/migrations/000058_factor_score_ttl.up.sql
@@ -1,0 +1,12 @@
+-- Install pg_cron if not already present and schedule a nightly job to
+-- delete factor_score rows older than 2 weeks. factor_score is a computed
+-- cache; scores that haven't been needed in two weeks are unlikely to be
+-- needed again, and they can always be recomputed on demand.
+
+CREATE EXTENSION IF NOT EXISTS pg_cron;
+
+SELECT cron.schedule(
+    'expire-factor-scores',
+    '0 3 * * *',
+    $$DELETE FROM factor_score WHERE created_at < now() - INTERVAL '2 weeks'$$
+);


### PR DESCRIPTION
## Summary
- Installs `pg_cron` extension (idempotent) and schedules a nightly job at 3 AM UTC
- Deletes `factor_score` rows where `created_at < now() - 2 weeks`
- `factor_score` is a computed cache; stale entries are never needed and can always be recomputed on demand

## Test plan
- [ ] Apply migration on prod and verify `cron.job` table contains `expire-factor-scores`
- [ ] Optionally run a manual `DELETE FROM factor_score WHERE created_at < now() - INTERVAL '2 weeks'` to clear the existing ~1M stale rows

🤖 Generated with [Claude Code](https://claude.com/claude-code)