### PR TITLE
fix(deploy): set VITE_API_BASE_URL so prod bundle hits api.factor.trade

### DIFF
--- a/.github/workflows/deploy-frontend.yml
+++ b/.github/workflows/deploy-frontend.yml
@@ -39,6 +39,8 @@ jobs:
 
       - name: Build
         working-directory: frontend-v2
+        env:
+          VITE_API_BASE_URL: https://api.factor.trade
         run: npm run build
 
       - name: Configure AWS credentials


### PR DESCRIPTION
## Summary

`VITE_API_BASE_URL` was not set in the deploy workflow, so Vite was inlining `http://localhost:3009` into the production bundle. This caused all API calls and the Google OAuth redirect on the live site to point at localhost.

One change: add `VITE_API_BASE_URL: https://api.factor.trade` to the Build step env.

🤖 Generated with [Claude Code](https://claude.com/claude-code)