### PR TITLE
Remove dollar amount display from backtest view

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,4 @@ frontend/test-results
 # vim swap files
 *.swp
 *.swo
+.vite

--- a/frontend-v2/src/pages/Backtest/BacktestPage.tsx
+++ b/frontend-v2/src/pages/Backtest/BacktestPage.tsx
@@ -403,7 +403,6 @@ export function BacktestPage(): React.ReactNode {
           <DayInspector
             date={inspectorDate}
             holdings={inspector?.holdings ?? []}
-            value={inspector?.value ?? null}
             pctChange={inspector?.pctChange ?? null}
             onClose={() => {
               setSelectedDate(null);

--- a/frontend-v2/src/pages/Backtest/DayInspector.tsx
+++ b/frontend-v2/src/pages/Backtest/DayInspector.tsx
@@ -8,7 +8,6 @@ import { cn } from '@/lib/utils';
 interface Props {
   date: string | null;
   holdings: HoldingRow[];
-  value: number | null;
   pctChange: number | null;
   // Bubbled up so consumers can clear the selection (e.g. close button
   // on the panel header).
@@ -20,13 +19,7 @@ interface Props {
 // at-a-glance bar for each weight, and the asset's price change to
 // next rebalance. This is the "what did the strategy do that day"
 // affordance the user asked for.
-export function DayInspector({
-  date,
-  holdings,
-  value,
-  pctChange,
-  onClose,
-}: Props): React.ReactNode {
+export function DayInspector({ date, holdings, pctChange, onClose }: Props): React.ReactNode {
   const empty = !date || holdings.length === 0;
 
   return (
@@ -42,15 +35,6 @@ export function DayInspector({
         </div>
         {date && (
           <div className="flex items-center gap-3">
-            {value !== null && (
-              <span className="font-mono text-sm text-muted-foreground">
-                ${' '}
-                {value.toLocaleString('en-US', {
-                  minimumFractionDigits: 2,
-                  maximumFractionDigits: 2,
-                })}
-              </span>
-            )}
             {pctChange !== null && (
               <span
                 className={cn(

--- a/frontend-v2/src/pages/Backtest/EquityChart.tsx
+++ b/frontend-v2/src/pages/Backtest/EquityChart.tsx
@@ -35,21 +35,11 @@ interface Props {
 interface HeadlineState {
   pct: number;
   date: string;
-  // value in starting-cash units, e.g. $11,234.56. May be undefined
-  // for benchmark-only points — we always lock onto the strategy
-  // series for the headline so this is effectively always defined.
-  value: number | undefined;
 }
 
 // ----- Animated big-number readout for the headline. Lives inline so
 // the chart owns its choreography end-to-end. -----
-function HeadlineNumber({
-  pct,
-  value,
-}: {
-  pct: number;
-  value: number | undefined;
-}): React.ReactNode {
+function HeadlineNumber({ pct }: { pct: number }): React.ReactNode {
   const reduceMotion = useReducedMotion();
   const motionValue = useMotionValue(pct);
   const spring = useSpring(motionValue, { stiffness: 220, damping: 26, mass: 0.4 });
@@ -78,20 +68,9 @@ function HeadlineNumber({
       <span className="text-[11px] uppercase tracking-[0.18em] text-subtle-foreground">
         Strategy return
       </span>
-      <div className="flex items-baseline gap-3">
-        <span className={cn('font-mono text-5xl font-semibold tracking-tight', colorClass)}>
-          {formatDelta(shown)}
-        </span>
-        {value !== undefined && (
-          <span className="font-mono text-base text-muted-foreground">
-            ${' '}
-            {value.toLocaleString('en-US', {
-              minimumFractionDigits: 2,
-              maximumFractionDigits: 2,
-            })}
-          </span>
-        )}
-      </div>
+      <span className={cn('font-mono text-5xl font-semibold tracking-tight', colorClass)}>
+        {formatDelta(shown)}
+      </span>
     </div>
   );
 }
@@ -212,7 +191,6 @@ export function EquityChart({
     ? {
         pct: lockedStrategyPoint.pctReturn,
         date: lockedStrategyPoint.date,
-        value: lockedStrategyPoint.value,
       }
     : null;
 
@@ -280,7 +258,7 @@ export function EquityChart({
     <div ref={containerRef} className="relative h-full w-full overflow-hidden">
       {/* Floating headline (top-left). Lifts above the chart canvas. */}
       <div className="pointer-events-none absolute left-6 top-6 z-10">
-        {headline && <HeadlineNumber pct={headline.pct} value={headline.value} />}
+        {headline && <HeadlineNumber pct={headline.pct} />}
         {headline && (
           <div className="mt-1 font-mono text-xs text-muted-foreground">
             {formatDateLong(headline.date)}

--- a/frontend-v2/src/pages/Backtest/chart-types.ts
+++ b/frontend-v2/src/pages/Backtest/chart-types.ts
@@ -9,10 +9,6 @@ export interface ChartPoint {
   // (0.12 = +12%). Plotting returns instead of dollar values lets
   // strategy + SPY share a y-axis with no normalization weirdness.
   pctReturn: number;
-  // Original strategy value (in starting-cash units) — preserved for
-  // the day inspector / tooltip headline. Undefined for benchmark
-  // points since SPY only carries % data.
-  value?: number;
 }
 
 export interface ChartSeries {

--- a/frontend-v2/src/pages/Backtest/transform.ts
+++ b/frontend-v2/src/pages/Backtest/transform.ts
@@ -48,11 +48,10 @@ export function snapshotsToStrategyPoints(result: BacktestResponse): ChartPoint[
   return dates.map((d) => {
     const snap = map[d];
     if (!snap) {
-      return { date: d, pctReturn: 0, value: startValue };
+      return { date: d, pctReturn: 0 };
     }
     return {
       date: d,
-      value: snap.value,
       pctReturn: snap.value / startValue - 1,
     };
   });
@@ -64,7 +63,7 @@ export function snapshotsToStrategyPoints(result: BacktestResponse): ChartPoint[
 export function snapshotToHoldings(
   result: BacktestResponse,
   date: string,
-): { holdings: HoldingRow[]; value: number; pctChange: number } | null {
+): { holdings: HoldingRow[]; pctChange: number } | null {
   const map = asSnapshotMap(result.backtestSnapshots);
   if (!map) return null;
   const snap = map[date];
@@ -89,7 +88,6 @@ export function snapshotToHoldings(
   // valuePercentChange is also in percentage points on the wire.
   return {
     holdings,
-    value: snap.value,
     pctChange: (snap.valuePercentChange ?? 0) / 100,
   };
 }


### PR DESCRIPTION
Removes the portfolio dollar value display from:
- EquityChart headline (was shown next to percentage return)
- DayInspector header

Also removes the value field from ChartPoint type and the transform functions that were computing/returning it. The backtest view now only shows percentage returns, not dollar amounts.