### PR TITLE
cron: replace Lambda with Fly supercronic process group

### DIFF
--- a/Dockerfile.fly
+++ b/Dockerfile.fly
@@ -29,11 +29,21 @@ FROM debian:bookworm-slim AS runtime
 
 WORKDIR /app
 
-RUN apt-get update && apt-get install -y --no-install-recommends tini ca-certificates && rm -rf /var/lib/apt/lists/*
+# curl is needed by the cron process to hit internal endpoints.
+# supercronic replaces raw cron; it logs to stdout, respects SIGTERM,
+# and doesn't require a setuid binary.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    tini ca-certificates curl && rm -rf /var/lib/apt/lists/*
+
+ARG SUPERCRONIC_VERSION=v0.2.29
+RUN curl -fsSLo /usr/local/bin/supercronic \
+    https://github.com/aptible/supercronic/releases/download/${SUPERCRONIC_VERSION}/supercronic-linux-amd64 \
+    && chmod +x /usr/local/bin/supercronic
 
 COPY --from=go-build /out/api /app/api
 COPY --from=go-build /out/migrate /app/migrate
 COPY --from=go-build /src/templates /app/templates
+COPY crontab /app/crontab
 
 ARG commit_hash
 ENV commit_hash=$commit_hash

--- a/api/api.go
+++ b/api/api.go
@@ -147,9 +147,13 @@ func (m ApiHandler) InitializeRouterEngine(ctx context.Context) *gin.Engine {
 	engine.GET("/activeInvestments", m.getInvestments)
 	engine.GET("/publishedStrategies", m.getPublishedStrategies)
 
-	engine.POST("/rebalance", m.rebalance)
-	engine.POST("/updateOrders", m.updateOrders)
-	engine.POST("/sendSavedStrategySummaryEmails", m.sendSavedStrategySummaryEmails)
+	// Internal cron endpoints — only callable by the supercronic process
+	// group via a shared secret. Never expose these without requireCronSecret.
+	cron := engine.Group("/internal/cron")
+	cron.Use(m.requireCronSecret)
+	cron.POST("/rebalance", m.rebalance)
+	cron.POST("/updateOrders", m.updateOrders)
+	cron.POST("/sendSavedStrategySummaryEmails", m.sendSavedStrategySummaryEmails)
 
 	return engine
 }
@@ -206,6 +210,18 @@ func blockBots(c *gin.Context) {
 			c.Abort()
 			return
 		}
+	}
+	c.Next()
+}
+
+// requireCronSecret guards /internal/cron/* routes. The supercronic process
+// group injects CRON_SECRET via the Fly secret of the same name; any request
+// missing or mismatching the header gets a 403 before reaching the handler.
+func (m ApiHandler) requireCronSecret(c *gin.Context) {
+	secret := os.Getenv("CRON_SECRET")
+	if secret == "" || c.GetHeader("X-Cron-Secret") != secret {
+		c.AbortWithStatusJSON(http.StatusForbidden, gin.H{"error": "forbidden"})
+		return
 	}
 	c.Next()
 }

--- a/crontab
+++ b/crontab
@@ -1,0 +1,14 @@
+# Supercronic crontab for factorbacktest Fly.io cron process group.
+# Times are in America/New_York. CRON_SECRET must be set as a Fly secret.
+# The cron process group hits /internal/cron/* on the web process via the
+# public app URL so it works even when the web Machine auto-stops.
+TZ=America/New_York
+
+# Morning pulse email — 8:30 AM weekdays
+30 8 * * 1-5 curl -fsS -X POST https://api.factor.trade/internal/cron/sendSavedStrategySummaryEmails -H "X-Cron-Secret: $CRON_SECRET"
+
+# Rebalance — 10:00 AM weekdays
+0 10 * * 1-5 curl -fsS -X POST https://api.factor.trade/internal/cron/rebalance -H "X-Cron-Secret: $CRON_SECRET"
+
+# Update pending orders — every 15 min during market hours (10 AM–4 PM weekdays)
+*/15 10-16 * * 1-5 curl -fsS -X POST https://api.factor.trade/internal/cron/updateOrders -H "X-Cron-Secret: $CRON_SECRET"

--- a/fly.toml
+++ b/fly.toml
@@ -12,6 +12,14 @@ primary_region = "iad"
   # rather than half-migrated.
   release_command = "/app/migrate"
 
+# Two process groups: web serves HTTP traffic, cron runs supercronic.
+# Fly creates a separate Machine for each group and scales them independently.
+# Only web is wired to the http_service so the cron Machine is never exposed
+# publicly. Scale cron to exactly 1 to avoid duplicate job fires.
+[processes]
+  web  = "/app/api"
+  cron = "supercronic /app/crontab"
+
 [env]
   FB_SECRETS_FROM_ENV = "1"
   GIN_MODE = "release"
@@ -35,6 +43,7 @@ primary_region = "iad"
   # + initial Postgres TLS handshake), and that's an acceptable tradeoff
   # for not paying for a warm machine 24/7.
   min_machines_running = 0
+  processes = ["web"]
 
   [[http_service.checks]]
     method = "get"
@@ -46,3 +55,9 @@ primary_region = "iad"
 [[vm]]
   size = "shared-cpu-2x"
   memory = "1gb"
+  processes = ["web"]
+
+[[vm]]
+  size = "shared-cpu-1x"
+  memory = "256mb"
+  processes = ["cron"]


### PR DESCRIPTION
## What

Replaces the old AWS Lambda cron jobs with a Fly-native `cron` process group running [Supercronic](https://github.com/aptible/supercronic).

## Changes

### `Dockerfile.fly`
- Add `curl` to the apt install step (needed by the cron process to hit internal endpoints)
- Download and install `supercronic` binary (`v0.2.29`)
- Copy `crontab` into the image at `/app/crontab`

### `crontab` (new file)
Three jobs, all weekdays, America/New_York:
- `30 8 * * 1-5` — morning summary email
- `0 10 * * 1-5` — rebalance
- `*/15 10-16 * * 1-5` — update pending orders every 15 min during market hours

Each job hits a protected `/internal/cron/*` endpoint with `X-Cron-Secret`.

### `fly.toml`
- Add `[processes]` block: `web = "/app/api"`, `cron = "supercronic /app/crontab"`
- Scope `[http_service]` and the web `[[vm]]` to `processes = ["web"]` so the cron Machine is never publicly exposed
- Add a smaller `[[vm]]` config (`shared-cpu-1x`, 256mb) for the `cron` process group

### `api/api.go`
- Remove the three loose top-level `engine.POST` registrations for `/rebalance`, `/updateOrders`, `/sendSavedStrategySummaryEmails`
- Add a `cron` route group at `/internal/cron` protected by the new `requireCronSecret` middleware
- Add `requireCronSecret` middleware: checks `X-Cron-Secret` header against the `CRON_SECRET` env var, 403s otherwise

## Deploy steps (after merge)

```bash
# Set the secret once — crontab reads it at runtime
fly secrets set CRON_SECRET=$(openssl rand -hex 32) -a factorbacktest

fly deploy

# Scale the new cron process group to exactly 1 Machine
fly scale count web=1 cron=1 -a factorbacktest
```

## Why Supercronic over Cron Manager

Cron Manager is the more isolated/auditable Fly option but requires a separate app with its own deploy pipeline and secrets. For three low-criticality endpoint pings this is unnecessary overhead. Supercronic lives inside the existing image, adds ~20MB, and can be migrated to Cron Manager later without touching the Go code (the `/internal/cron/*` endpoints are identical either way).