### PR TITLE
Restore Fly cron jobs with Supercronic

### DIFF
--- a/.github/workflows/deploy-fly.yml
+++ b/.github/workflows/deploy-fly.yml
@@ -12,6 +12,7 @@ on:
       - 'go.sum'
       - 'Makefile'
       - 'Dockerfile.fly'
+      - 'crontab'
       - 'fly.toml'
       - 'migrations/**'
       - 'tools/**'

--- a/Dockerfile.fly
+++ b/Dockerfile.fly
@@ -29,11 +29,24 @@ FROM debian:bookworm-slim AS runtime
 
 WORKDIR /app
 
-RUN apt-get update && apt-get install -y --no-install-recommends tini ca-certificates && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    tini ca-certificates curl \
+    && rm -rf /var/lib/apt/lists/*
+
+ENV SUPERCRONIC_URL=https://github.com/aptible/supercronic/releases/download/v0.2.29/supercronic-linux-amd64 \
+    SUPERCRONIC=supercronic-linux-amd64 \
+    SUPERCRONIC_SHA1SUM=cd48d45c4b10f3f0bfdd3a57d054cd05ac96812b
+
+RUN curl -fsSLO "$SUPERCRONIC_URL" \
+    && echo "${SUPERCRONIC_SHA1SUM}  ${SUPERCRONIC}" | sha1sum -c - \
+    && chmod +x "$SUPERCRONIC" \
+    && mv "$SUPERCRONIC" "/usr/local/bin/${SUPERCRONIC}" \
+    && ln -s "/usr/local/bin/${SUPERCRONIC}" /usr/local/bin/supercronic
 
 COPY --from=go-build /out/api /app/api
 COPY --from=go-build /out/migrate /app/migrate
 COPY --from=go-build /src/templates /app/templates
+COPY crontab /app/crontab
 
 ARG commit_hash
 ENV commit_hash=$commit_hash

--- a/api/api.go
+++ b/api/api.go
@@ -147,9 +147,11 @@ func (m ApiHandler) InitializeRouterEngine(ctx context.Context) *gin.Engine {
 	engine.GET("/activeInvestments", m.getInvestments)
 	engine.GET("/publishedStrategies", m.getPublishedStrategies)
 
-	engine.POST("/rebalance", m.rebalance)
-	engine.POST("/updateOrders", m.updateOrders)
-	engine.POST("/sendSavedStrategySummaryEmails", m.sendSavedStrategySummaryEmails)
+	cron := engine.Group("/internal/cron")
+	cron.Use(m.requireCronSecret)
+	cron.POST("/rebalance", m.rebalance)
+	cron.POST("/updateOrders", m.updateOrders)
+	cron.POST("/sendSavedStrategySummaryEmails", m.sendSavedStrategySummaryEmails)
 
 	return engine
 }
@@ -381,6 +383,15 @@ func (m ApiHandler) getGoogleAuthMiddleware(c *gin.Context) {
 func (m ApiHandler) requireAuthenticatedUser(c *gin.Context) {
 	if _, ok := c.Get("userAccountID"); !ok {
 		returnErrorJsonCode(fmt.Errorf("authentication required"), c, 401)
+		return
+	}
+	c.Next()
+}
+
+func (m ApiHandler) requireCronSecret(c *gin.Context) {
+	secret := os.Getenv("CRON_SECRET")
+	if secret == "" || c.GetHeader("X-Cron-Secret") != secret {
+		c.AbortWithStatusJSON(http.StatusForbidden, gin.H{"error": "forbidden"})
 		return
 	}
 	c.Next()

--- a/api/endpoints.yaml
+++ b/api/endpoints.yaml
@@ -5,19 +5,21 @@
 # - Update api.go router registration
 
 endpoints:
-  - path: /updateOrders
+  - path: /internal/cron/updateOrders
     method: POST
     handler: updateOrders
     requires_auth: false
     generate_resolver: false
+    register_route: false
     request:
     response:
       success: string
 
-  - path: /sendSavedStrategySummaryEmails
+  - path: /internal/cron/sendSavedStrategySummaryEmails
     method: POST
     handler: sendSavedStrategySummaryEmails
     requires_auth: false
+    register_route: false
     request:
       # Empty object means no request body
     response:

--- a/crontab
+++ b/crontab
@@ -1,0 +1,10 @@
+TZ=America/New_York
+
+# Morning saved-strategy summary email - 8:30am ET on weekdays.
+30 8 * * 1-5 curl -fsS -X POST https://api.factor.trade/internal/cron/sendSavedStrategySummaryEmails -H "X-Cron-Secret: $CRON_SECRET"
+
+# Trigger portfolio rebalancing - 10:00am ET on weekdays.
+0 10 * * 1-5 curl -fsS -X POST https://api.factor.trade/internal/cron/rebalance -H "X-Cron-Secret: $CRON_SECRET"
+
+# Poll pending broker orders during the trading day so completed fills are reflected in local state.
+*/15 10-16 * * 1-5 curl -fsS -X POST https://api.factor.trade/internal/cron/updateOrders -H "X-Cron-Secret: $CRON_SECRET"

--- a/fly.toml
+++ b/fly.toml
@@ -25,6 +25,10 @@ primary_region = "iad"
   # change it.
   FACTOR_AUTH_FRONTEND_BASE_URL = "https://factor.trade"
 
+[processes]
+  web = "/app/api"
+  cron = "supercronic /app/crontab"
+
 [http_service]
   internal_port = 3009
   force_https = true
@@ -35,6 +39,7 @@ primary_region = "iad"
   # + initial Postgres TLS handshake), and that's an acceptable tradeoff
   # for not paying for a warm machine 24/7.
   min_machines_running = 0
+  processes = ["web"]
 
   [[http_service.checks]]
     method = "get"

--- a/integration-tests/backtest_test.go
+++ b/integration-tests/backtest_test.go
@@ -11,6 +11,8 @@ import (
 	"io"
 	"math"
 	"net/http"
+	"os"
+	"strings"
 	"testing"
 	"time"
 
@@ -34,6 +36,9 @@ func hitEndpoint(baseURL, route string, method string, payload interface{}, targ
 
 	if method == http.MethodPost {
 		req.Header.Set("Content-Type", "application/json")
+	}
+	if strings.HasPrefix(route, "internal/cron/") {
+		req.Header.Set("X-Cron-Secret", os.Getenv("CRON_SECRET"))
 	}
 
 	// Send the request

--- a/integration-tests/rebalance_test.go
+++ b/integration-tests/rebalance_test.go
@@ -87,6 +87,8 @@ func (s *TestServer) Stop() error {
 }
 
 func Test_rebalanceFlow(t *testing.T) {
+	t.Setenv("CRON_SECRET", "test-cron-secret")
+
 	manager, err := NewTestDbManager()
 	require.NoError(t, err)
 
@@ -134,7 +136,7 @@ func Test_rebalanceFlow(t *testing.T) {
 	startTime := time.Now()
 	request := map[string]string{}
 	response := map[string]string{}
-	err = hitEndpoint(server.URL, "rebalance", http.MethodPost, request, &response)
+	err = hitEndpoint(server.URL, "internal/cron/rebalance", http.MethodPost, request, &response)
 	require.NoError(t, err)
 	elapsed := time.Since(startTime).Milliseconds()
 

--- a/tools/generate_api.py
+++ b/tools/generate_api.py
@@ -261,7 +261,11 @@ def update_api_go(endpoints: List[Dict[str, Any]]) -> None:
         method = endpoint['method'].upper()
         path = endpoint['path']
         handler = endpoint['handler']
-        
+
+        if endpoint.get('register_route') is False:
+            print(f"  Skipping {path} (register_route: false)")
+            continue
+
         # Skip if route already exists
         if path in existing_paths:
             print(f"  Skipping {path} (already registered)")


### PR DESCRIPTION
## Summary
- Add Fly `web` and `cron` process groups and keep proxy traffic limited to `web`.
- Install Supercronic and curl in the Fly runtime image, and add a crontab for the three scheduled workflow endpoint pings.
- Move cron endpoints under `/internal/cron/*` and require `X-Cron-Secret`; include `crontab` in Fly deploy path filters.

## Verification
- `go build ./...`
- `go test ./api ./cmd/api ./cmd/migrate`
- `git diff --check`

## Note
- `go test ./...` was attempted locally, but DB-backed tests failed because local Postgres was not available on `localhost:5440`. CI provides Postgres for the full test suite.

Closes SAS-27