### PR TITLE
Fix paused investments blocking rebalances

### DIFF
--- a/api/get_investments.resolver.go
+++ b/api/get_investments.resolver.go
@@ -125,7 +125,7 @@ func getInvestmentsResponseFromDomain(in map[uuid.UUID]service.GetStatsResponse)
 			PercentReturnFraction: stats.PercentReturnFraction.InexactFloat64(),
 			CurrentValue:          stats.CurrentValue.InexactFloat64(),
 			CompletedTrades:       completedTrades,
-			Paused:                false,
+			Paused:                stats.Paused,
 		})
 	}
 

--- a/internal/service/investment.service.go
+++ b/internal/service/investment.service.go
@@ -123,7 +123,6 @@ func (h investmentServiceHandler) Add(ctx context.Context, userAccountID uuid.UU
 		UserAccountID: userAccountID,
 		AmountDollars: int32(amount),
 		StartDate:     date,
-		PausedAt:      util.TimePointer(time.Now().UTC()),
 	})
 	if err != nil {
 		return err
@@ -164,6 +163,7 @@ type GetStatsResponse struct {
 	Holdings              []domain.Position
 	OriginalAmount        int32
 	StartDate             time.Time
+	Paused                bool
 	PercentReturnFraction decimal.Decimal
 	CurrentValue          decimal.Decimal
 	CompletedTrades       []domain.FilledTrade
@@ -233,6 +233,7 @@ func (h investmentServiceHandler) GetStats(ctx context.Context, investmentID uui
 		CompletedTrades:       completedTrades,
 		Strategy:              *strategy,
 		OriginalAmount:        investment.AmountDollars,
+		Paused:                investment.PausedAt != nil,
 	}, nil
 }
 

--- a/internal/service/trade.service.go
+++ b/internal/service/trade.service.go
@@ -368,7 +368,7 @@ func (h tradeServiceHandler) updateOrder(tx *sql.Tx, tradeOrderID uuid.UUID) (*m
 
 	state := tradeOrder.Status
 	// check valid state transition
-	if order.Status == "expired" || order.Status == "cancelled" {
+	if order.Status == "expired" || order.Status == "canceled" || order.Status == "cancelled" || order.ExpiredAt != nil || order.CanceledAt != nil {
 		state = model.TradeOrderStatus_Canceled
 	} else if state == model.TradeOrderStatus_Pending && order.FilledAt != nil {
 		state = model.TradeOrderStatus_Completed

--- a/migrations/000059_unpause_active_investments.down.sql
+++ b/migrations/000059_unpause_active_investments.down.sql
@@ -1,0 +1,1 @@
+-- Irreversible data correction: previous paused_at timestamps are not recoverable.

--- a/migrations/000059_unpause_active_investments.up.sql
+++ b/migrations/000059_unpause_active_investments.up.sql
@@ -1,0 +1,4 @@
+update investment
+set paused_at = null
+where end_date is null
+  and paused_at is not null;


### PR DESCRIPTION
## Summary
- stop creating new investments with paused_at set
- return the real paused state from activeInvestments instead of always false
- add a one-time migration to clear paused_at on active investments so existing investments become eligible for rebalancing
- handle Alpaca canceled/canceled_at order responses when reconciling pending orders

## Prod debugging notes
- production has 2 open investments: 1 unpaused, 1 paused
- production has 2 PENDING trade orders from 2026-05-07, which blocks subsequent rebalances for that investment
- Fly cron calls are currently receiving 403 because CRON_SECRET is missing from app secrets

## Testing
- PASS: go test ./api
- PASS: go test ./api ./internal/data ./internal/logger ./internal/progress ./pkg/treasury
- FAIL: go test ./... because DB-backed tests expect local Postgres on localhost:5440, which is not running in this environment
