### PR TITLE
Use Neon database URLs

### DIFF
--- a/cmd/migrate/main.go
+++ b/cmd/migrate/main.go
@@ -35,7 +35,7 @@ func main() {
 	if err != nil {
 		log.Fatalf("migrate: load secrets: %v", err)
 	}
-	db, err := sql.Open("postgres", secrets.Db.ToConnectionStr())
+	db, err := sql.Open("postgres", util.MigrationConnectionStr(*secrets))
 	if err != nil {
 		log.Fatalf("migrate: open db: %v", err)
 	}

--- a/cmd/util.go
+++ b/cmd/util.go
@@ -63,15 +63,15 @@ func InitializeDependencies(secrets util.Secrets, overrides *api.ApiHandler) (*a
 	// long-lived API process talking to managed Postgres:
 	//
 	// - Unlimited MaxOpenConns lets a traffic burst (or a runaway query)
-	//   blow past the RDS connection cap and start failing requests with
-	//   "too many connections for role". 25 is comfortably under the
-	//   db.t-class default and matches the steady-state we already observe
+	//   blow past the managed Postgres connection cap and start failing requests with
+	//   "too many connections for role". 25 stays comfortably below typical
+	//   managed Postgres limits and matches the steady-state we already observe
 	//   in pg_stat_activity.
 	// - MaxIdleConns=2 is too low for our 10-goroutine fan-outs (see
 	//   factor_score.repository.go). On a burst the pool returns 10 conns
 	//   but only keeps 2 idle, closing the rest. The next batch then pays
 	//   a fresh TLS handshake (~3 RTT) per new conn.
-	// - ConnMaxLifetime=infinite means a connection killed by RDS-side
+	// - ConnMaxLifetime=infinite means a connection killed by database-side
 	//   maintenance/failover sits in the pool until we try to use it and
 	//   get a half-open socket error. 30m forces a periodic refresh.
 	// - ConnMaxIdleTime=5m frees conns that were opened during a burst and

--- a/docs/latency.md
+++ b/docs/latency.md
@@ -23,33 +23,33 @@ instead — that's a separate concern handled by a different process.
 | ------------------------------------ | ------------------------------------------------------------------- |
 | `https://api.factor.trade`           | The Fly deployment under test.                                      |
 | `https://tgwmxgtk07.execute-api.us-east-1.amazonaws.com/prod` | The legacy AWS Lambda deployment, kept alive as a baseline. |
-| `secrets.json` / `secrets-dev.json`  | Postgres creds for prod RDS (`alpha.cuutadkicrvi.us-east-2.rds.amazonaws.com`). |
+| `DATABASE_URL` / `MIGRATE_DATABASE_URL` | Neon Postgres URLs used by the Fly API and release migrations. |
 | `api_request` table                  | Every request: `request_id`, `route`, `start_ts`, `duration_ms`, `version` (deploy SHA), `request_body`, `ip_address`. |
 | `latency_tracking` table             | One row per request, jsonb tree of `(name, elapsed, subSpans)` spans. |
 | `latency_span_stats` view            | Flat `(request_id, route, start_ts, version, span_path, depth, elapsed_ms)`. **Use this; it's why we did the work.** |
 | `flyctl logs` / `flyctl status`      | Real-time process logs and machine state.                           |
 
-The Fly egress-IP-to-RDS path measures ~22ms TCP RTT. The Lambda path
-measures ~12ms. So the same code paying the same query count will be
-~10ms-per-round-trip slower on Fly than on Lambda by physics alone — keep
-that floor in mind when interpreting numbers.
+The Fly-to-Neon path should be measured during each investigation. So the
+same code paying the same query count may still differ between Fly and the
+historical Lambda baseline by network placement alone — keep that floor in
+mind when interpreting numbers.
 
 ## Why we kept the Lambda URL as a baseline
 
 The Lambda backend (PR #117 removed the deploy pipeline but the function
-itself is still hot) ran the same Go binary against the same RDS for years.
+itself is still hot) ran the same Go binary against the same database for years.
 Its measured wall-clock numbers are the **closest thing we have to a
 ground-truth lower bound** for any /backtest workload, because:
 
 - Same source tree (commit `26911f2` is what's deployed on Lambda).
-- Same RDS database. Same network neighborhood (us-east-1 → us-east-2 inside AWS).
+- Same application data; the current Fly deployment uses Neon Postgres.
 - Different runtime (Lambda Graviton ARM, no scale-to-zero penalty after the
   first invocation).
 
 So the rule is: **a Fly investigation is a success when Fly approaches or
 beats Lambda's wall-clock for the same payload**. If Fly is much slower than
-Lambda, the gap is either network (us-east-2 RDS over the public internet
-from Fly Ashburn) or a real regression, and the spans will tell you which.
+Lambda, the gap is either network placement or a real regression, and the
+spans will tell you which.
 
 ## The loop
 
@@ -91,12 +91,12 @@ from Fly Ashburn) or a real regression, and the spans will tell you which.
 brew install libpq
 export PATH="/opt/homebrew/opt/libpq/bin:$PATH"
 
-# DB env. Pulled from secrets.json at the repo root.
-export PGHOST=alpha.cuutadkicrvi.us-east-2.rds.amazonaws.com
-export PGUSER=postgres
-export PGDATABASE=postgres
+# DB env. Pulled from Neon or from Fly's DATABASE_URL secret.
+export PGHOST='<neon-host>'
+export PGUSER='<neon-user>'
+export PGDATABASE='<neon-database>'
 export PGPORT=5432
-export PGPASSWORD="$(jq -r .db.password secrets.json)"
+export PGPASSWORD='<neon-password>'
 
 # Sanity: should print server time.
 psql -c "select now();"
@@ -284,7 +284,7 @@ after any change to see the delta on each span independently.
 
 ## Step 6: Compare Fly to the Lambda baseline
 
-Both backends write to the same RDS. Lambda rows are tagged
+Both backends write to the same logical application database. Lambda rows are tagged
 `version = '26911f2'` and have `ip_address IS NULL` (API Gateway strips it
 through the Lambda proxy by default). Fly rows have `version` =
 deploy-SHA and `ip_address` = your client's IP.

--- a/internal/util/util.go
+++ b/internal/util/util.go
@@ -9,9 +9,11 @@ import (
 	"factorbacktest/internal/db/models/postgres/public/model"
 	"factorbacktest/internal/logger"
 	"fmt"
+	"net/url"
 	"os"
 	"regexp"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/google/uuid"
@@ -101,6 +103,7 @@ type AlpacaSecrets struct {
 }
 
 type DbSecrets struct {
+	URL       string `json:"url"`
 	Host      string `json:"host"`
 	User      string `json:"user"`
 	Port      string `json:"port"`
@@ -125,12 +128,42 @@ type ResendSecrets struct {
 }
 
 func (t DbSecrets) ToConnectionStr() string {
+	if t.URL != "" {
+		return sanitizePostgresURL(t.URL)
+	}
+
 	x := fmt.Sprintf("host=%s port=%s user=%s password=%s dbname=%s",
 		t.Host, t.Port, t.User, t.Password, t.Database)
 	if !t.EnableSsl {
 		x += " sslmode=disable"
 	}
 	return x
+}
+
+func MigrationConnectionStr(secrets Secrets) string {
+	if v := os.Getenv("MIGRATE_DATABASE_URL"); v != "" {
+		return sanitizePostgresURL(v)
+	}
+	return secrets.Db.ToConnectionStr()
+}
+
+func sanitizePostgresURL(raw string) string {
+	if !strings.HasPrefix(raw, "postgres://") && !strings.HasPrefix(raw, "postgresql://") {
+		return raw
+	}
+
+	u, err := url.Parse(raw)
+	if err != nil {
+		return raw
+	}
+
+	// Neon connection strings often include channel_binding=require. lib/pq
+	// does not consume that option as a driver setting, so it can be forwarded
+	// as a PostgreSQL startup parameter. Strip it before handing the URL to pq.
+	q := u.Query()
+	q.Del("channel_binding")
+	u.RawQuery = q.Encode()
+	return u.String()
 }
 
 func LoadSecrets() (*Secrets, error) {
@@ -204,14 +237,17 @@ func loadSecretsFromEnv() (*Secrets, error) {
 	required := map[string]string{
 		"dataJockey": get("dataJockey"),
 		"gpt":        get("gpt"),
-		"host":       get("host"),
-		"port":       get("port"),
-		"user":       get("user"),
-		"password":   get("password"),
-		"database":   get("database"),
 		"apiKey":     get("apiKey"),
 		"apiSecret":  get("apiSecret"),
 		"endpoint":   get("endpoint"),
+	}
+	dbURL := get("DATABASE_URL")
+	if dbURL == "" {
+		required["host"] = get("host")
+		required["port"] = get("port")
+		required["user"] = get("user")
+		required["password"] = get("password")
+		required["database"] = get("database")
 	}
 	var missing []string
 	for k, v := range required {
@@ -249,6 +285,7 @@ func loadSecretsFromEnv() (*Secrets, error) {
 		DataJockeyApiKey: required["dataJockey"],
 		ChatGPTApiKey:    required["gpt"],
 		Db: DbSecrets{
+			URL:       dbURL,
 			Host:      required["host"],
 			Port:      required["port"],
 			User:      required["user"],

--- a/internal/util/util_test.go
+++ b/internal/util/util_test.go
@@ -1,0 +1,74 @@
+package util
+
+import (
+	"strings"
+	"testing"
+)
+
+func setRequiredEnv(t *testing.T) {
+	t.Helper()
+	t.Setenv("dataJockey", "data-jockey")
+	t.Setenv("gpt", "gpt")
+	t.Setenv("apiKey", "alpaca-key")
+	t.Setenv("apiSecret", "alpaca-secret")
+	t.Setenv("endpoint", "alpaca-endpoint")
+}
+
+func TestLoadSecretsFromEnvPrefersDatabaseURL(t *testing.T) {
+	setRequiredEnv(t)
+	t.Setenv("DATABASE_URL", "postgresql://user:pass@ep-test.us-east-1.aws.neon.tech/neondb?sslmode=require&channel_binding=require")
+
+	secrets, err := loadSecretsFromEnv()
+	if err != nil {
+		t.Fatalf("loadSecretsFromEnv() error = %v", err)
+	}
+
+	connStr := secrets.Db.ToConnectionStr()
+	if !strings.Contains(connStr, "ep-test.us-east-1.aws.neon.tech") {
+		t.Fatalf("connection string did not use DATABASE_URL: %q", connStr)
+	}
+	if strings.Contains(connStr, "channel_binding") {
+		t.Fatalf("connection string still contains channel_binding: %q", connStr)
+	}
+	if !strings.Contains(connStr, "sslmode=require") {
+		t.Fatalf("connection string should preserve sslmode=require: %q", connStr)
+	}
+}
+
+func TestLoadSecretsFromEnvFallsBackToSplitDBFields(t *testing.T) {
+	setRequiredEnv(t)
+	t.Setenv("host", "db.example.com")
+	t.Setenv("port", "5432")
+	t.Setenv("user", "db-user")
+	t.Setenv("password", "db-pass")
+	t.Setenv("database", "app-db")
+	t.Setenv("enableSsl", "false")
+
+	secrets, err := loadSecretsFromEnv()
+	if err != nil {
+		t.Fatalf("loadSecretsFromEnv() error = %v", err)
+	}
+
+	want := "host=db.example.com port=5432 user=db-user password=db-pass dbname=app-db sslmode=disable"
+	if got := secrets.Db.ToConnectionStr(); got != want {
+		t.Fatalf("ToConnectionStr() = %q, want %q", got, want)
+	}
+}
+
+func TestMigrationConnectionStrPrefersMigrateDatabaseURL(t *testing.T) {
+	t.Setenv("MIGRATE_DATABASE_URL", "postgresql://migrator:pass@ep-migrate.us-east-1.aws.neon.tech/neondb?sslmode=require&channel_binding=require")
+
+	secrets := Secrets{
+		Db: DbSecrets{
+			URL: "postgresql://app:pass@ep-app.us-east-1.aws.neon.tech/neondb?sslmode=require",
+		},
+	}
+
+	connStr := MigrationConnectionStr(secrets)
+	if !strings.Contains(connStr, "ep-migrate.us-east-1.aws.neon.tech") {
+		t.Fatalf("MigrationConnectionStr() did not use MIGRATE_DATABASE_URL: %q", connStr)
+	}
+	if strings.Contains(connStr, "channel_binding") {
+		t.Fatalf("migration connection string still contains channel_binding: %q", connStr)
+	}
+}


### PR DESCRIPTION
## Summary
- Add support for `DATABASE_URL` and `MIGRATE_DATABASE_URL` so the Fly API and release migrations can connect to Neon Postgres instead of split host/user/password fields.
- Strip `channel_binding=require` from Neon connection strings before handing them to `lib/pq`, which otherwise forwards it as an unsupported startup parameter.
- Update latency investigation docs to reference Neon URLs instead of the legacy RDS host.

## Test plan
- [x] `go test ./internal/util/...`
- [ ] Deploy to Fly with `DATABASE_URL` and `MIGRATE_DATABASE_URL` set and confirm API starts cleanly
- [ ] Run release migrations against Neon via `MIGRATE_DATABASE_URL`


Made with [Cursor](https://cursor.com)