### PR TITLE
Make price ingestion resilient to bad symbols

### DIFF
--- a/api/update_prices.resolver.go
+++ b/api/update_prices.resolver.go
@@ -1,34 +1,41 @@
 package api
 
 import (
+	"factorbacktest/internal/repository"
 	"github.com/gin-gonic/gin"
 )
 
 type UpdatePricesResponse struct {
-	NumUpdatedAssets int `json:"numUpdatedAssets"`
+	NumUpdatedAssets int      `json:"numUpdatedAssets"`
+	FailedSymbols    []string `json:"failedSymbols"`
 }
 
 func (m ApiHandler) updatePrices(c *gin.Context) {
-	tx, err := m.Db.Begin()
+	assets, err := m.AssetUniverseRepository.GetAssets("ALL")
 	if err != nil {
 		returnErrorJson(err, c)
 		return
 	}
 
-	numUpdatedAssets, err := m.PriceService.UpdateUniversePrices(c, tx, m.TickerRepository, m.PriceRepository)
-	if err != nil {
-		returnErrorJson(err, c)
-		return
+	symbols := make([]string, 0, len(assets)+1)
+	for _, asset := range assets {
+		if asset.Symbol != repository.CASH_SYMBOL {
+			symbols = append(symbols, asset.Symbol)
+		}
 	}
+	// SPY is the benchmark and is intentionally ingested even if no strategy
+	// universe happens to contain it.
+	symbols = append(symbols, "SPY")
 
-	err = tx.Commit()
+	result, err := m.PriceService.UpdatePrices(c, symbols, m.PriceRepository)
 	if err != nil {
 		returnErrorJson(err, c)
 		return
 	}
 
 	out := UpdatePricesResponse{
-		NumUpdatedAssets: numUpdatedAssets,
+		NumUpdatedAssets: len(result.UpdatedSymbols),
+		FailedSymbols:    result.FailedSymbols,
 	}
 
 	c.JSON(200, out)

--- a/integration-tests/mocks.go
+++ b/integration-tests/mocks.go
@@ -31,8 +31,8 @@ func (m mockPriceServiceForTestsHandler) IngestPrices(ctx context.Context, tx *s
 	return fmt.Errorf("IngestPrices not implemented")
 }
 
-func (m mockPriceServiceForTestsHandler) UpdateUniversePrices(ctx context.Context, tx *sql.Tx, tickerRepository repository.TickerRepository, adjPricesRepository repository.AdjustedPriceRepository) (int, error) {
-	return 0, fmt.Errorf("UpdateUniversePrices not implemented")
+func (m mockPriceServiceForTestsHandler) UpdatePrices(ctx context.Context, symbols []string, adjPricesRepository repository.AdjustedPriceRepository) (data.PriceUpdateResult, error) {
+	return data.PriceUpdateResult{}, fmt.Errorf("UpdatePrices not implemented")
 }
 
 func (m mockPriceServiceForTestsHandler) LoadPriceCache(ctx context.Context, inputs []data.LoadPriceCacheInput, stdevs []data.LoadStdevCacheInput) (*data.PriceCache, error) {

--- a/internal/data/mocks/mock_price.service.go
+++ b/internal/data/mocks/mock_price.service.go
@@ -88,17 +88,17 @@ func (mr *MockPriceServiceMockRecorder) LoadPriceCache(ctx, inputs, stdevs any) 
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LoadPriceCache", reflect.TypeOf((*MockPriceService)(nil).LoadPriceCache), ctx, inputs, stdevs)
 }
 
-// UpdateUniversePrices mocks base method.
-func (m *MockPriceService) UpdateUniversePrices(ctx context.Context, tx *sql.Tx, tickerRepository repository.TickerRepository, adjPricesRepository repository.AdjustedPriceRepository) (int, error) {
+// UpdatePrices mocks base method.
+func (m *MockPriceService) UpdatePrices(ctx context.Context, symbols []string, adjPricesRepository repository.AdjustedPriceRepository) (data.PriceUpdateResult, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "UpdateUniversePrices", ctx, tx, tickerRepository, adjPricesRepository)
-	ret0, _ := ret[0].(int)
+	ret := m.ctrl.Call(m, "UpdatePrices", ctx, symbols, adjPricesRepository)
+	ret0, _ := ret[0].(data.PriceUpdateResult)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// UpdateUniversePrices indicates an expected call of UpdateUniversePrices.
-func (mr *MockPriceServiceMockRecorder) UpdateUniversePrices(ctx, tx, tickerRepository, adjPricesRepository any) *gomock.Call {
+// UpdatePrices indicates an expected call of UpdatePrices.
+func (mr *MockPriceServiceMockRecorder) UpdatePrices(ctx, symbols, adjPricesRepository any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateUniversePrices", reflect.TypeOf((*MockPriceService)(nil).UpdateUniversePrices), ctx, tx, tickerRepository, adjPricesRepository)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdatePrices", reflect.TypeOf((*MockPriceService)(nil).UpdatePrices), ctx, symbols, adjPricesRepository)
 }

--- a/internal/data/price.service.go
+++ b/internal/data/price.service.go
@@ -30,7 +30,12 @@ type PriceService interface {
 	LoadPriceCache(ctx context.Context, inputs []LoadPriceCacheInput, stdevs []LoadStdevCacheInput) (*PriceCache, error)
 	GetLatestPrices(ctx context.Context, symbols []string) (map[string]decimal.Decimal, error)
 	IngestPrices(ctx context.Context, tx *sql.Tx, symbol string, adjPricesRepository repository.AdjustedPriceRepository, start *time.Time) error
-	UpdateUniversePrices(ctx context.Context, tx *sql.Tx, tickerRepository repository.TickerRepository, adjPricesRepository repository.AdjustedPriceRepository) (int, error)
+	UpdatePrices(ctx context.Context, symbols []string, adjPricesRepository repository.AdjustedPriceRepository) (PriceUpdateResult, error)
+}
+
+type PriceUpdateResult struct {
+	UpdatedSymbols []string
+	FailedSymbols  []string
 }
 
 type LoadPriceCacheInput struct {
@@ -454,7 +459,7 @@ func (h priceServiceHandler) IngestPrices(
 	adjPricesRepository repository.AdjustedPriceRepository,
 	start *time.Time,
 ) error {
-	s := time.Date(2000, 1, 0, 0, 0, 0, 0, time.UTC)
+	s := time.Date(2000, 1, 1, 0, 0, 0, 0, time.UTC)
 	if start != nil {
 		s = *start
 	}
@@ -463,6 +468,9 @@ func (h priceServiceHandler) IngestPrices(
 	points, err := h.QuoteProvider.GetDailyAdjCloses(ctx, symbol, s, now)
 	if err != nil {
 		return err
+	}
+	if len(points) == 0 {
+		return fmt.Errorf("no daily price data returned")
 	}
 
 	models := []model.AdjustedPrice{}
@@ -483,76 +491,118 @@ func (h priceServiceHandler) IngestPrices(
 	return nil
 }
 
-func (h priceServiceHandler) UpdateUniversePrices(
+const (
+	priceUpdateWorkers  = 5
+	priceRefreshOverlap = 7 * 24 * time.Hour
+)
+
+func (h priceServiceHandler) UpdatePrices(
 	ctx context.Context,
-	tx *sql.Tx,
-	tickerRepository repository.TickerRepository,
+	symbols []string,
 	adjPricesRepository repository.AdjustedPriceRepository,
-) (int, error) {
+) (PriceUpdateResult, error) {
 	log := logger.FromContext(ctx)
 
-	assets, err := tickerRepository.List()
+	symbols = uniqueSymbols(symbols)
+	if len(symbols) == 0 {
+		return PriceUpdateResult{}, fmt.Errorf("no symbols supplied for price update")
+	}
+
+	latestDates, err := adjPricesRepository.LatestPriceDates(symbols)
 	if err != nil {
-		return 0, err
-	}
-	if len(assets) == 0 {
-		return 0, fmt.Errorf("no assets found in universe")
+		return PriceUpdateResult{}, err
 	}
 
-	assets = append(assets, model.Ticker{
-		Symbol: "SPY",
-	})
+	log.Infof("updating prices for %d active symbols", len(symbols))
+	result := h.asyncIngestPrices(ctx, symbols, latestDates, adjPricesRepository)
+	log.Infof("updated prices for %d symbols; %d failed", len(result.UpdatedSymbols), len(result.FailedSymbols))
 
-	symbols := []string{}
-	for _, a := range assets {
-		symbols = append(symbols, a.Symbol)
+	if len(result.UpdatedSymbols) == 0 && len(result.FailedSymbols) > 0 {
+		return result, fmt.Errorf("failed to update prices for every symbol")
+	}
+	if err := ctx.Err(); err != nil {
+		return result, err
 	}
 
-	log.Infof("found %d assets to update", len(assets))
-
-	h.asyncIngestPrices(ctx, tx, symbols, adjPricesRepository)
-
-	log.Infof("updated %d prices", len(symbols))
-
-	return len(symbols), nil
+	return result, nil
 }
 
-func (h priceServiceHandler) asyncIngestPrices(ctx context.Context, tx *sql.Tx, symbols []string, adjPriceRepository repository.AdjustedPriceRepository) error {
+func (h priceServiceHandler) asyncIngestPrices(ctx context.Context, symbols []string, latestDates map[string]time.Time, adjPriceRepository repository.AdjustedPriceRepository) PriceUpdateResult {
 	log := logger.FromContext(ctx)
-	numGoroutines := 10
+	type ingestResult struct {
+		symbol string
+		err    error
+	}
 
-	inputCh := make(chan string, len(symbols))
+	inputCh := make(chan string)
+	resultCh := make(chan ingestResult, len(symbols))
 
 	var wg sync.WaitGroup
-	for _, f := range symbols {
-		wg.Add(1)
-		inputCh <- f
-	}
-	close(inputCh)
-
-	for i := 0; i < numGoroutines; i++ {
+	wg.Add(priceUpdateWorkers)
+	for i := 0; i < priceUpdateWorkers; i++ {
 		go func() {
-			for {
-				select {
-				case <-ctx.Done():
-					return
-				case symbol, ok := <-inputCh:
-					if !ok {
-						return
-					}
-					err := h.IngestPrices(ctx, tx, symbol, adjPriceRepository, nil)
-					if err != nil {
-						log.Warnf("failed to ingest price for %s: %s\n", symbol, err.Error())
-					}
-					wg.Done()
-				}
+			defer wg.Done()
+			for symbol := range inputCh {
+				start := incrementalPriceStart(latestDates[symbol])
+				// nil uses the repository's database handle, making this symbol's
+				// upsert independent from every other symbol.
+				err := h.IngestPrices(ctx, nil, symbol, adjPriceRepository, start)
+				resultCh <- ingestResult{symbol: symbol, err: err}
 			}
 		}()
 	}
 
-	wg.Wait()
+	go func() {
+		defer close(inputCh)
+		for _, symbol := range symbols {
+			select {
+			case <-ctx.Done():
+				return
+			case inputCh <- symbol:
+			}
+		}
+	}()
 
-	return nil
+	go func() {
+		wg.Wait()
+		close(resultCh)
+	}()
+
+	result := PriceUpdateResult{}
+	for ingest := range resultCh {
+		if ingest.err != nil {
+			log.Warnf("failed to ingest price for %s: %s", ingest.symbol, ingest.err)
+			result.FailedSymbols = append(result.FailedSymbols, ingest.symbol)
+			continue
+		}
+		result.UpdatedSymbols = append(result.UpdatedSymbols, ingest.symbol)
+	}
+
+	return result
+}
+
+func incrementalPriceStart(latestDate time.Time) *time.Time {
+	if latestDate.IsZero() {
+		return nil
+	}
+	start := latestDate.Add(-priceRefreshOverlap)
+	return &start
+}
+
+func uniqueSymbols(symbols []string) []string {
+	seen := make(map[string]struct{}, len(symbols))
+	out := make([]string, 0, len(symbols))
+	for _, symbol := range symbols {
+		if symbol == "" || symbol == repository.CASH_SYMBOL {
+			continue
+		}
+		if _, ok := seen[symbol]; ok {
+			continue
+		}
+		seen[symbol] = struct{}{}
+		out = append(out, symbol)
+	}
+	return out
 }
 
 // i absolutely hate this function but it's the only way to get the latest price using yahoo finance

--- a/internal/data/price.service_test.go
+++ b/internal/data/price.service_test.go
@@ -2,12 +2,19 @@ package data
 
 import (
 	"context"
+	"database/sql"
+	"factorbacktest/internal/db/models/postgres/public/model"
+	"factorbacktest/internal/repository"
+	mock_repository "factorbacktest/internal/repository/mocks"
 	"factorbacktest/internal/util"
+	"fmt"
+	"sync"
 	"testing"
 	"time"
 
 	"github.com/shopspring/decimal"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
 )
 
 // import (
@@ -209,4 +216,69 @@ func Test_priceServiceHandler_GetLatestPrices(t *testing.T) {
 			"AAPL": decimal.NewFromFloat(100),
 		}, resp)
 	})
+}
+
+func TestPriceServiceUpdatePricesCommitsSuccessfulSymbolsIndependently(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	prices := mock_repository.NewMockAdjustedPriceRepository(ctrl)
+	latestDate := time.Date(2026, 7, 10, 0, 0, 0, 0, time.UTC)
+
+	prices.EXPECT().LatestPriceDates([]string{"AAPL", "BAD"}).Return(map[string]time.Time{
+		"AAPL": latestDate,
+	}, nil)
+	prices.EXPECT().Add(nil, gomock.Any()).DoAndReturn(func(_ *sql.Tx, models []model.AdjustedPrice) error {
+		require.Len(t, models, 1)
+		require.Equal(t, "AAPL", models[0].Symbol)
+		return nil
+	})
+
+	provider := &recordingQuoteProvider{
+		points: map[string][]DailyPricePoint{
+			"AAPL": {{Date: latestDate.AddDate(0, 0, 1), Price: decimal.NewFromInt(200)}},
+		},
+		errors: map[string]error{
+			"BAD": fmt.Errorf("symbol not found"),
+		},
+	}
+	service := priceServiceHandler{QuoteProvider: provider}
+
+	result, err := service.UpdatePrices(context.Background(), []string{"AAPL", "BAD", "AAPL", repository.CASH_SYMBOL}, prices)
+
+	require.NoError(t, err)
+	require.Equal(t, []string{"AAPL"}, result.UpdatedSymbols)
+	require.Equal(t, []string{"BAD"}, result.FailedSymbols)
+	require.Equal(t, latestDate.Add(-priceRefreshOverlap), provider.startFor("AAPL"))
+}
+
+type recordingQuoteProvider struct {
+	points map[string][]DailyPricePoint
+	errors map[string]error
+
+	mu     sync.Mutex
+	starts map[string]time.Time
+}
+
+func (p *recordingQuoteProvider) ProviderName() string { return "test" }
+
+func (p *recordingQuoteProvider) GetLatestQuotes(context.Context, []string) (*QuoteResponse, error) {
+	return nil, fmt.Errorf("not implemented")
+}
+
+func (p *recordingQuoteProvider) GetDailyAdjCloses(_ context.Context, symbol string, start, _ time.Time) ([]DailyPricePoint, error) {
+	p.mu.Lock()
+	if p.starts == nil {
+		p.starts = map[string]time.Time{}
+	}
+	p.starts[symbol] = start
+	p.mu.Unlock()
+	if err := p.errors[symbol]; err != nil {
+		return nil, err
+	}
+	return p.points[symbol], nil
+}
+
+func (p *recordingQuoteProvider) startFor(symbol string) time.Time {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return p.starts[symbol]
 }

--- a/internal/repository/adj_price.repository.go
+++ b/internal/repository/adj_price.repository.go
@@ -54,6 +54,7 @@ type AdjustedPriceRepository interface {
 	ListTradingDays(start, end time.Time) ([]time.Time, error)
 	LatestTradingDay() (*time.Time, error)
 	LatestPrices(symbols []string) ([]domain.AssetPrice, error)
+	LatestPriceDates(symbols []string) (map[string]time.Time, error)
 
 	// this is weird
 	GetMany([]GetManyInput) ([]domain.AssetPrice, error)
@@ -298,6 +299,49 @@ func (h adjustedPriceRepositoryHandler) LatestPrices(symbols []string) ([]domain
 			Date:   model.Date,
 			Price:  model.Price,
 		})
+	}
+
+	return out, nil
+}
+
+// LatestPriceDates returns only symbols that already have price history. A
+// missing map entry is therefore an intentional signal to backfill a symbol.
+func (h adjustedPriceRepositoryHandler) LatestPriceDates(symbols []string) (map[string]time.Time, error) {
+	if len(symbols) == 0 {
+		return map[string]time.Time{}, nil
+	}
+
+	symbolExpressions := make([]postgres.Expression, 0, len(symbols))
+	for _, symbol := range symbols {
+		symbolExpressions = append(symbolExpressions, postgres.String(symbol))
+	}
+
+	query := table.AdjustedPrice.
+		SELECT(
+			table.AdjustedPrice.Symbol,
+			postgres.MAX(table.AdjustedPrice.Date).AS("latest_date"),
+		).
+		WHERE(table.AdjustedPrice.Symbol.IN(symbolExpressions...)).
+		GROUP_BY(table.AdjustedPrice.Symbol)
+
+	q, args := query.Sql()
+	rows, err := h.Db.Query(q, args...)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get latest price dates: %w", err)
+	}
+	defer rows.Close()
+
+	out := make(map[string]time.Time, len(symbols))
+	for rows.Next() {
+		var symbol string
+		var date time.Time
+		if err := rows.Scan(&symbol, &date); err != nil {
+			return nil, fmt.Errorf("failed to scan latest price date: %w", err)
+		}
+		out[symbol] = date
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("failed to read latest price dates: %w", err)
 	}
 
 	return out, nil

--- a/internal/repository/mocks/mock_adj_price.repository.go
+++ b/internal/repository/mocks/mock_adj_price.repository.go
@@ -103,6 +103,21 @@ func (mr *MockAdjustedPriceRepositoryMockRecorder) GetManyOnDay(arg0, arg1 any) 
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetManyOnDay", reflect.TypeOf((*MockAdjustedPriceRepository)(nil).GetManyOnDay), arg0, arg1)
 }
 
+// LatestPriceDates mocks base method.
+func (m *MockAdjustedPriceRepository) LatestPriceDates(symbols []string) (map[string]time.Time, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "LatestPriceDates", symbols)
+	ret0, _ := ret[0].(map[string]time.Time)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// LatestPriceDates indicates an expected call of LatestPriceDates.
+func (mr *MockAdjustedPriceRepositoryMockRecorder) LatestPriceDates(symbols any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LatestPriceDates", reflect.TypeOf((*MockAdjustedPriceRepository)(nil).LatestPriceDates), symbols)
+}
+
 // LatestPrices mocks base method.
 func (m *MockAdjustedPriceRepository) LatestPrices(symbols []string) ([]domain.AssetPrice, error) {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
## Summary

- derive price updates from active asset-universe membership instead of every ticker row
- remove the shared transaction so one failed Yahoo/database write cannot roll back other symbols
- fetch from each symbol's latest stored date with a seven-day overlap, while retaining full history for new symbols
- return failed symbols in the update response for operational visibility

## Verification

- ok  	factorbacktest/api	(cached)
ok  	factorbacktest/internal/data	(cached)
- 
- ok  	factorbacktest/api	(cached)
?   	factorbacktest/api/models	[no test files]
?   	factorbacktest/cmd	[no test files]
?   	factorbacktest/cmd/api	[no test files]
?   	factorbacktest/cmd/migrate	[no test files]
?   	factorbacktest/cmd/test-api	[no test files]
ok  	factorbacktest/internal	(cached)
?   	factorbacktest/internal/app	[no test files]
?   	factorbacktest/internal/app/mocks	[no test files]
?   	factorbacktest/internal/auth	[no test files]
?   	factorbacktest/internal/calculator	[no test files]
?   	factorbacktest/internal/calculator/mocks	[no test files]
ok  	factorbacktest/internal/data	(cached)
?   	factorbacktest/internal/data/mocks	[no test files]
?   	factorbacktest/internal/db/models/postgres/app_auth/model	[no test files]
?   	factorbacktest/internal/db/models/postgres/app_auth/table	[no test files]
?   	factorbacktest/internal/db/models/postgres/public/enum	[no test files]
?   	factorbacktest/internal/db/models/postgres/public/model	[no test files]
?   	factorbacktest/internal/db/models/postgres/public/table	[no test files]
?   	factorbacktest/internal/db/models/postgres/public/view	[no test files]
?   	factorbacktest/internal/domain	[no test files]
ok  	factorbacktest/internal/logger	(cached)
ok  	factorbacktest/internal/progress	(cached)
--- FAIL: Test_assetUniverseRepositoryHandler_GetAssets (0.01s)
    --- FAIL: Test_assetUniverseRepositoryHandler_GetAssets/get_assets_from_one_universe (0.00s)
        asset_universe.repository_test.go:140: 
            	Error Trace:	/home/sahil/projects/factorbacktest/internal/repository/asset_universe.repository_test.go:140
            	Error:      	Received unexpected error:
            	            	dial tcp [::1]:5440: connect: connection refused
            	Test:       	Test_assetUniverseRepositoryHandler_GetAssets/get_assets_from_one_universe
    --- FAIL: Test_assetUniverseRepositoryHandler_GetAssets/get_assets_from_all_universes (0.00s)
        asset_universe.repository_test.go:157: 
            	Error Trace:	/home/sahil/projects/factorbacktest/internal/repository/asset_universe.repository_test.go:157
            	Error:      	Received unexpected error:
            	            	dial tcp [::1]:5440: connect: connection refused
            	Test:       	Test_assetUniverseRepositoryHandler_GetAssets/get_assets_from_all_universes
FAIL
FAIL	factorbacktest/internal/repository	0.019s
?   	factorbacktest/internal/repository/mocks	[no test files]
--- FAIL: Test_investmentServiceHandler_rebalanceInvestment (0.00s)
    --- FAIL: Test_investmentServiceHandler_rebalanceInvestment/rebalance_from_existing_holdings (0.00s)
        investment.service_test.go:50: 
            	Error Trace:	/home/sahil/projects/factorbacktest/internal/service/investment.service_test.go:50
            	Error:      	Received unexpected error:
            	            	dial tcp [::1]:5440: connect: connection refused
            	Test:       	Test_investmentServiceHandler_rebalanceInvestment/rebalance_from_existing_holdings
{"level":"warn","ts":1784045120.279684,"caller":"logger/logger.go:48","msg":"no logger found in ctx - creating new one","ALPHA_ENV":"","stacktrace":"factorbacktest/internal/logger.FromContext\n\t/home/sahil/projects/factorbacktest/internal/logger/logger.go:48\nfactorbacktest/internal/service.transitionToTarget\n\t/home/sahil/projects/factorbacktest/internal/service/investment.service.go:441\nfactorbacktest/internal/service.Test_transitionToTarget.func1\n\t/home/sahil/projects/factorbacktest/internal/service/investment.service_test.go:238\ntesting.tRunner\n\t/home/sahil/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.25.0.linux-amd64/src/testing/testing.go:1934"}
--- FAIL: Test_updatePortfoliosFromTrades (0.00s)
    --- FAIL: Test_updatePortfoliosFromTrades/ensure_sells_work (0.00s)
        trade.service_test.go:42: 
            	Error Trace:	/home/sahil/projects/factorbacktest/internal/service/trade.service_test.go:42
            	Error:      	Received unexpected error:
            	            	dial tcp [::1]:5440: connect: connection refused
            	Test:       	Test_updatePortfoliosFromTrades/ensure_sells_work
{"level":"warn","ts":1784045120.2837312,"caller":"logger/logger.go:48","msg":"no logger found in ctx - creating new one","ALPHA_ENV":"","stacktrace":"factorbacktest/internal/logger.FromContext\n\t/home/sahil/projects/factorbacktest/internal/logger/logger.go:48\nfactorbacktest/internal/service.aggregateAndFormatTrades\n\t/home/sahil/projects/factorbacktest/internal/service/trade.service.go:191\nfactorbacktest/internal/service.tradeServiceHandler.ExecuteBlock\n\t/home/sahil/projects/factorbacktest/internal/service/trade.service.go:257\nfactorbacktest/internal/service.Test_tradeServiceHandler_ExecuteBlock.func1\n\t/home/sahil/projects/factorbacktest/internal/service/trade.service_test.go:251\ntesting.tRunner\n\t/home/sahil/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.25.0.linux-amd64/src/testing/testing.go:1934"}
{"level":"info","ts":1784045120.283857,"caller":"service/trade.service.go:241","msg":"total excess amount: 0.000000. breakdown map[]","ALPHA_ENV":"","stacktrace":"factorbacktest/internal/service.aggregateAndFormatTrades\n\t/home/sahil/projects/factorbacktest/internal/service/trade.service.go:241\nfactorbacktest/internal/service.tradeServiceHandler.ExecuteBlock\n\t/home/sahil/projects/factorbacktest/internal/service/trade.service.go:257\nfactorbacktest/internal/service.Test_tradeServiceHandler_ExecuteBlock.func1\n\t/home/sahil/projects/factorbacktest/internal/service/trade.service_test.go:251\ntesting.tRunner\n\t/home/sahil/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.25.0.linux-amd64/src/testing/testing.go:1934"}
{"level":"warn","ts":1784045120.2867923,"caller":"logger/logger.go:48","msg":"no logger found in ctx - creating new one","ALPHA_ENV":"","stacktrace":"factorbacktest/internal/logger.FromContext\n\t/home/sahil/projects/factorbacktest/internal/logger/logger.go:48\nfactorbacktest/internal/service.aggregateAndFormatTrades\n\t/home/sahil/projects/factorbacktest/internal/service/trade.service.go:191\nfactorbacktest/internal/service.tradeServiceHandler.ExecuteBlock\n\t/home/sahil/projects/factorbacktest/internal/service/trade.service.go:257\nfactorbacktest/internal/service.Test_tradeServiceHandler_ExecuteBlock.func2.1\n\t/home/sahil/projects/factorbacktest/internal/service/trade.service_test.go:375\ntesting.tRunner\n\t/home/sahil/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.25.0.linux-amd64/src/testing/testing.go:1934"}
{"level":"info","ts":1784045120.2879333,"caller":"service/trade.service.go:241","msg":"total excess amount: 0.500000. breakdown map[0fd54474-d23d-44ac-982d-5448c7f65a17:0.5]","ALPHA_ENV":"","stacktrace":"factorbacktest/internal/service.aggregateAndFormatTrades\n\t/home/sahil/projects/factorbacktest/internal/service/trade.service.go:241\nfactorbacktest/internal/service.tradeServiceHandler.ExecuteBlock\n\t/home/sahil/projects/factorbacktest/internal/service/trade.service.go:257\nfactorbacktest/internal/service.Test_tradeServiceHandler_ExecuteBlock.func2.1\n\t/home/sahil/projects/factorbacktest/internal/service/trade.service_test.go:375\ntesting.tRunner\n\t/home/sahil/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.25.0.linux-amd64/src/testing/testing.go:1934"}
{"level":"warn","ts":1784045120.2898498,"caller":"logger/logger.go:48","msg":"no logger found in ctx - creating new one","ALPHA_ENV":"","stacktrace":"factorbacktest/internal/logger.FromContext\n\t/home/sahil/projects/factorbacktest/internal/logger/logger.go:48\nfactorbacktest/internal/service.aggregateAndFormatTrades\n\t/home/sahil/projects/factorbacktest/internal/service/trade.service.go:191\nfactorbacktest/internal/service.tradeServiceHandler.ExecuteBlock\n\t/home/sahil/projects/factorbacktest/internal/service/trade.service.go:257\nfactorbacktest/internal/service.Test_tradeServiceHandler_ExecuteBlock.func2.2\n\t/home/sahil/projects/factorbacktest/internal/service/trade.service_test.go:509\ntesting.tRunner\n\t/home/sahil/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.25.0.linux-amd64/src/testing/testing.go:1934"}
{"level":"info","ts":1784045120.2899535,"caller":"service/trade.service.go:241","msg":"total excess amount: 2.064418. breakdown map[13e32998-2292-4b46-8cd1-522e32f2b596:1.3204961070091486]","ALPHA_ENV":"","stacktrace":"factorbacktest/internal/service.aggregateAndFormatTrades\n\t/home/sahil/projects/factorbacktest/internal/service/trade.service.go:241\nfactorbacktest/internal/service.tradeServiceHandler.ExecuteBlock\n\t/home/sahil/projects/factorbacktest/internal/service/trade.service.go:257\nfactorbacktest/internal/service.Test_tradeServiceHandler_ExecuteBlock.func2.2\n\t/home/sahil/projects/factorbacktest/internal/service/trade.service_test.go:509\ntesting.tRunner\n\t/home/sahil/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.25.0.linux-amd64/src/testing/testing.go:1934"}
--- FAIL: Test_tradeServiceHandler_ExecuteBlock (0.01s)
    --- FAIL: Test_tradeServiceHandler_ExecuteBlock/simple_buys (0.00s)
        trade.service_test.go:257: 
            	Error Trace:	/home/sahil/projects/factorbacktest/internal/service/trade.service_test.go:257
            	Error:      	Received unexpected error:
            	            	dial tcp [::1]:5440: connect: connection refused
            	Test:       	Test_tradeServiceHandler_ExecuteBlock/simple_buys
        controller.go:98: missing call(s) to *mock_repository.MockTradeOrderRepository.Update(is nil, is equal to bbf3f14c-8518-4d7f-900c-fde7a20e94fd (uuid.UUID), is anything, is equal to [0xc0001fbd10 0xc0001fbc20 0xc0001fbd60 0xc0001fbdb0 0xc0001fbe00] (jet.ColumnList)) /home/sahil/projects/factorbacktest/internal/service/trade.service_test.go:667
        controller.go:98: missing call(s) to *mock_repository.MockTradeOrderRepository.Update(is nil, is equal to b7e57953-ef8a-4d10-9a5d-928127ad1b2a (uuid.UUID), is anything, is equal to [0xc0001fbd10 0xc0001fbc20 0xc0001fbd60 0xc0001fbdb0 0xc0001fbe00] (jet.ColumnList)) /home/sahil/projects/factorbacktest/internal/service/trade.service_test.go:667
        controller.go:98: missing call(s) to *mock_repository.MockTradeOrderRepository.Add(is nil, is trade order with given TradeOrderID) /home/sahil/projects/factorbacktest/internal/service/trade.service_test.go:604
        controller.go:98: missing call(s) to *mock_repository.MockTradeOrderRepository.Add(is nil, is trade order with given TradeOrderID) /home/sahil/projects/factorbacktest/internal/service/trade.service_test.go:604
        controller.go:98: missing call(s) to *mock_repository.MockAlpacaRepository.PlaceOrder(is alpaca order with matching symbol) /home/sahil/projects/factorbacktest/internal/service/trade.service_test.go:635
        controller.go:98: missing call(s) to *mock_repository.MockAlpacaRepository.PlaceOrder(is alpaca order with matching symbol) /home/sahil/projects/factorbacktest/internal/service/trade.service_test.go:635
        controller.go:98: aborting test due to missing call(s)
    --- FAIL: Test_tradeServiceHandler_ExecuteBlock/ensure_excess_trades_tracked (0.00s)
        --- FAIL: Test_tradeServiceHandler_ExecuteBlock/ensure_excess_trades_tracked/track_excess (0.00s)
            trade.service_test.go:381: 
                	Error Trace:	/home/sahil/projects/factorbacktest/internal/service/trade.service_test.go:381
                	Error:      	Received unexpected error:
                	            	dial tcp [::1]:5440: connect: connection refused
                	Test:       	Test_tradeServiceHandler_ExecuteBlock/ensure_excess_trades_tracked/track_excess
            controller.go:98: missing call(s) to *mock_repository.MockExcessTradeVolumeRepository.Add(is anything, is anything) /home/sahil/projects/factorbacktest/internal/service/trade.service_test.go:320
            controller.go:98: missing call(s) to *mock_repository.MockTradeOrderRepository.Add(is nil, is trade order with given TradeOrderID) /home/sahil/projects/factorbacktest/internal/service/trade.service_test.go:604
            controller.go:98: missing call(s) to *mock_repository.MockAlpacaRepository.PlaceOrder(is alpaca order with matching symbol) /home/sahil/projects/factorbacktest/internal/service/trade.service_test.go:635
            controller.go:98: missing call(s) to *mock_repository.MockTradeOrderRepository.Update(is nil, is equal to e49e83f0-873f-40f6-8d1b-f2c04744a2e6 (uuid.UUID), is anything, is equal to [0xc0001fbd10 0xc0001fbc20 0xc0001fbd60 0xc0001fbdb0 0xc0001fbe00] (jet.ColumnList)) /home/sahil/projects/factorbacktest/internal/service/trade.service_test.go:667
            controller.go:98: missing call(s) to *mock_repository.MockExcessTradeVolumeRepository.Update(is anything, is anything, is equal to [0xc0001f3180] (jet.ColumnList)) /home/sahil/projects/factorbacktest/internal/service/trade.service_test.go:353
            controller.go:98: aborting test due to missing call(s)
        --- FAIL: Test_tradeServiceHandler_ExecuteBlock/ensure_excess_trades_tracked/complex_excess (0.00s)
            trade.service_test.go:515: 
                	Error Trace:	/home/sahil/projects/factorbacktest/internal/service/trade.service_test.go:515
                	Error:      	Received unexpected error:
                	            	dial tcp [::1]:5440: connect: connection refused
                	Test:       	Test_tradeServiceHandler_ExecuteBlock/ensure_excess_trades_tracked/complex_excess
            controller.go:98: missing call(s) to *mock_repository.MockTradeOrderRepository.Update(is nil, is equal to 281e626e-02e8-405d-a31f-b2e8424ef1d3 (uuid.UUID), is anything, is equal to [0xc0001fbd10 0xc0001fbc20 0xc0001fbd60 0xc0001fbdb0 0xc0001fbe00] (jet.ColumnList)) /home/sahil/projects/factorbacktest/internal/service/trade.service_test.go:667
            controller.go:98: missing call(s) to *mock_repository.MockExcessTradeVolumeRepository.Update(is anything, is anything, is equal to [0xc0001f3180] (jet.ColumnList)) /home/sahil/projects/factorbacktest/internal/service/trade.service_test.go:487
            controller.go:98: missing call(s) to *mock_repository.MockExcessTradeVolumeRepository.Add(is anything, is anything) /home/sahil/projects/factorbacktest/internal/service/trade.service_test.go:451
            controller.go:98: missing call(s) to *mock_repository.MockTradeOrderRepository.Add(is nil, is trade order with given TradeOrderID) /home/sahil/projects/factorbacktest/internal/service/trade.service_test.go:604
            controller.go:98: missing call(s) to *mock_repository.MockAlpacaRepository.PlaceOrder(is alpaca order with matching symbol) /home/sahil/projects/factorbacktest/internal/service/trade.service_test.go:635
            controller.go:98: aborting test due to missing call(s)
FAIL
FAIL	factorbacktest/internal/service	0.025s
?   	factorbacktest/internal/service/mocks	[no test files]
?   	factorbacktest/internal/testseed	[no test files]
ok  	factorbacktest/internal/util	(cached)
?   	factorbacktest/migrations	[no test files]
?   	factorbacktest/pkg/datajockey	[no test files]
?   	factorbacktest/pkg/google-auth	[no test files]
ok  	factorbacktest/pkg/treasury	(cached)
FAIL (database-backed repository/service tests require local Postgres on port 5440 and could not run in this environment)