### PR TITLE
Run scheduled jobs in Eastern time

### DIFF
--- a/Dockerfile.fly
+++ b/Dockerfile.fly
@@ -30,7 +30,7 @@ FROM debian:bookworm-slim AS runtime
 WORKDIR /app
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    tini ca-certificates curl \
+    tini ca-certificates curl tzdata \
     && rm -rf /var/lib/apt/lists/*
 
 ENV SUPERCRONIC_URL=https://github.com/aptible/supercronic/releases/download/v0.2.29/supercronic-linux-amd64 \

--- a/crontab
+++ b/crontab
@@ -1,5 +1,3 @@
-TZ=America/New_York
-
 # Morning saved-strategy summary email - 8:30am ET on weekdays.
 30 8 * * 1-5 curl -fsS -X POST https://api.factor.trade/internal/cron/sendSavedStrategySummaryEmails -H "X-Cron-Secret: $CRON_SECRET"
 

--- a/fly.toml
+++ b/fly.toml
@@ -15,6 +15,9 @@ primary_region = "iad"
 [env]
   FB_SECRETS_FROM_ENV = "1"
   GIN_MODE = "release"
+  # Supercronic reads TZ when it starts and schedules the crontab in this
+  # timezone. The runtime image includes tzdata for DST-aware ET scheduling.
+  TZ = "America/New_York"
 
   # Public base URL of the Go API. The internal/auth package uses this as
   # the OAuth redirect_uri host and as the issuer on internal tokens.


### PR DESCRIPTION
Summary:
- install timezone data in the Fly runtime image
- set America/New_York in the Fly process environment so Supercronic schedules with DST
- remove the misleading crontab-local timezone assignment

Verification:
- Fly configuration validates
- Dockerfile.fly builds locally
- Supercronic debug output computes the next rebalance at 2026-07-15 10:00:00 -0400 EDT