### PR TITLE
Add investment liquidation UI

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -116,6 +116,17 @@ func (m ApiHandler) InitializeRouterEngine(ctx context.Context) *gin.Engine {
 	if m.AuthService != nil {
 		engine.Use(m.AuthService.Middleware())
 		m.AuthService.RegisterRoutes(engine)
+	} else if m.AuthMiddleware != nil {
+		engine.GET("/auth/session", func(c *gin.Context) {
+			userAccountID, ok := c.Get("userAccountID")
+			if !ok {
+				c.JSON(http.StatusOK, gin.H{"user": nil})
+				return
+			}
+			c.JSON(http.StatusOK, gin.H{
+				"user": gin.H{"id": fmt.Sprint(userAccountID)},
+			})
+		})
 	}
 
 	engine.Use(m.getGoogleAuthMiddleware)

--- a/api/get_investments.resolver.go
+++ b/api/get_investments.resolver.go
@@ -12,15 +12,16 @@ import (
 )
 
 type GetInvestmentsResponse struct {
-	InvestmentID          uuid.UUID     `json:"investmentID"`
-	OriginalAmountDollars int32         `json:"originalAmountDollars"`
-	StartDate             string        `json:"startDate"`
-	Strategy              Strategy      `json:"strategy"`
-	Holdings              []Holdings    `json:"holdings"`
-	PercentReturnFraction float64       `json:"percentReturnFraction"`
-	CurrentValue          float64       `json:"currentValue"`
-	CompletedTrades       []FilledTrade `json:"completedTrades"`
-	Paused                bool          `json:"paused"`
+	InvestmentID           uuid.UUID     `json:"investmentID"`
+	OriginalAmountDollars  int32         `json:"originalAmountDollars"`
+	StartDate              string        `json:"startDate"`
+	LiquidationRequestedAt *string       `json:"liquidationRequestedAt"`
+	Strategy               Strategy      `json:"strategy"`
+	Holdings               []Holdings    `json:"holdings"`
+	PercentReturnFraction  float64       `json:"percentReturnFraction"`
+	CurrentValue           float64       `json:"currentValue"`
+	CompletedTrades        []FilledTrade `json:"completedTrades"`
+	Paused                 bool          `json:"paused"`
 }
 
 type Holdings struct {
@@ -109,10 +110,17 @@ func getInvestmentsResponseFromDomain(in map[uuid.UUID]service.GetStatsResponse)
 			})
 		}
 
+		var liquidationRequestedAt *string
+		if stats.LiquidationRequestedAt != nil {
+			formatted := stats.LiquidationRequestedAt.Format(time.RFC3339)
+			liquidationRequestedAt = &formatted
+		}
+
 		out = append(out, GetInvestmentsResponse{
-			InvestmentID:          investmentID,
-			OriginalAmountDollars: stats.OriginalAmount,
-			StartDate:             stats.StartDate.Format(time.DateOnly),
+			InvestmentID:           investmentID,
+			OriginalAmountDollars:  stats.OriginalAmount,
+			StartDate:              stats.StartDate.Format(time.DateOnly),
+			LiquidationRequestedAt: liquidationRequestedAt,
 			Strategy: Strategy{
 				StrategyID:        stats.Strategy.StrategyID,
 				StrategyName:      stats.Strategy.StrategyName,

--- a/api/get_investments.resolver_test.go
+++ b/api/get_investments.resolver_test.go
@@ -1,0 +1,26 @@
+package api
+
+import (
+	"factorbacktest/internal/service"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetInvestmentsResponseFromDomainIncludesLiquidationRequestedAt(t *testing.T) {
+	investmentID := uuid.New()
+	requestedAt := time.Date(2026, 7, 14, 15, 30, 0, 0, time.UTC)
+
+	out := getInvestmentsResponseFromDomain(map[uuid.UUID]service.GetStatsResponse{
+		investmentID: {
+			StartDate:              time.Date(2026, 4, 8, 0, 0, 0, 0, time.UTC),
+			LiquidationRequestedAt: &requestedAt,
+		},
+	})
+
+	require.Len(t, out, 1)
+	require.NotNil(t, out[0].LiquidationRequestedAt)
+	require.Equal(t, "2026-07-14T15:30:00Z", *out[0].LiquidationRequestedAt)
+}

--- a/cmd/test-api/main.go
+++ b/cmd/test-api/main.go
@@ -17,6 +17,8 @@ import (
 	"factorbacktest/cmd"
 	"factorbacktest/internal/logger"
 	"factorbacktest/internal/util"
+
+	"github.com/gin-gonic/gin"
 )
 
 var seedName = flag.String("seed", "", "name of seed to apply at startup")
@@ -69,6 +71,13 @@ func main() {
 		log.Fatalf("failed to initialize dependencies: %v", err)
 	}
 	apiHandler.Port = port
+	if seededUserAccountID != nil {
+		apiHandler.AuthMiddleware = func(c *gin.Context) {
+			c.Set("userAccountID", seededUserAccountID.String())
+			c.Next()
+		}
+		apiHandler.AuthService = nil
+	}
 
 	lg := logger.New()
 	ctx := context.WithValue(context.Background(), logger.ContextKey, lg)

--- a/cmd/test-api/seeds.go
+++ b/cmd/test-api/seeds.go
@@ -5,13 +5,21 @@ import (
 	"sort"
 	"time"
 
+	"factorbacktest/internal/db/models/postgres/public/model"
+	"factorbacktest/internal/db/models/postgres/public/table"
 	"factorbacktest/internal/testseed"
 
+	"github.com/go-jet/jet/v2/postgres"
 	"github.com/google/uuid"
+	"github.com/shopspring/decimal"
 )
 
+var seededUserAccountID *uuid.UUID
+
 var seeds = map[string]func(*sql.DB){
-	"home_strategies": seedHomeStrategies,
+	"home_strategies":        seedHomeStrategies,
+	"active_investment":      seedActiveInvestment,
+	"liquidating_investment": seedLiquidatingInvestment,
 }
 
 func seedHomeStrategies(db *sql.DB) {
@@ -68,6 +76,86 @@ func seedHomeStrategies(db *sql.DB) {
 		FactorExpression:  "pricePercentChange(\n  nDaysAgo(90),\n  currentDate\n)",
 		Published:         true,
 	})
+}
+
+func seedActiveInvestment(db *sql.DB) {
+	seedInvestment(db, false)
+}
+
+func seedLiquidatingInvestment(db *sql.DB) {
+	seedInvestment(db, true)
+}
+
+func seedInvestment(db *sql.DB, liquidationRequested bool) {
+	amd := testseed.CreateTicker(db, testseed.TickerOpts{Symbol: "AMD", Name: "Advanced Micro Devices"})
+	intc := testseed.CreateTicker(db, testseed.TickerOpts{Symbol: "INTC", Name: "Intel"})
+	amat := testseed.CreateTicker(db, testseed.TickerOpts{Symbol: "AMAT", Name: "Applied Materials"})
+	testseed.CreateTicker(db, testseed.TickerOpts{Symbol: "SPY", Name: "SPDR S&P 500 ETF"})
+
+	universe := testseed.CreateAssetUniverse(db, testseed.AssetUniverseOpts{
+		Name:        "SPY_TOP_80",
+		DisplayName: "SPY_TOP_80",
+	})
+	for _, id := range []uuid.UUID{amd.TickerID, intc.TickerID, amat.TickerID} {
+		testseed.CreateAssetUniverseTicker(db, universe.AssetUniverseID, id)
+	}
+
+	end := time.Now().UTC()
+	start := end.AddDate(-3, 0, -100)
+	testseed.InsertSyntheticPrices(db, testseed.SyntheticPricesOpts{
+		Symbols: []string{"AMD", "INTC", "AMAT", "SPY"},
+		Start:   start,
+		End:     end,
+	})
+
+	user := testseed.CreateUserAccount(db, testseed.UserAccountOpts{Email: "test@gmail.com"})
+	seededUserAccountID = &user.UserAccountID
+	strategy := testseed.CreateStrategy(db, testseed.StrategyOpts{
+		Name:              "Seeded Momentum",
+		UserAccountID:     user.UserAccountID,
+		AssetUniverse:     "SPY_TOP_80",
+		NumAssets:         3,
+		RebalanceInterval: "MONTHLY",
+		FactorExpression:  "pricePercentChange(\n  nDaysAgo(30),\n  currentDate\n)",
+		Published:         true,
+	})
+	investment := testseed.CreateInvestment(db, testseed.InvestmentOpts{
+		StrategyID:    strategy.StrategyID,
+		UserAccountID: user.UserAccountID,
+		AmountDollars: 100,
+		StartDate:     time.Now().UTC().AddDate(0, -3, 0),
+	})
+	if liquidationRequested {
+		now := time.Now().UTC()
+		_, err := table.Investment.
+			UPDATE(table.Investment.LiquidationRequestedAt, table.Investment.ModifiedAt).
+			SET(postgres.TimestampzT(now), postgres.TimestampzT(now)).
+			WHERE(table.Investment.InvestmentID.EQ(postgres.UUID(investment.InvestmentID))).
+			Exec(db)
+		if err != nil {
+			panic(err)
+		}
+	}
+
+	version := testseed.CreateInvestmentHoldingsVersion(db, investment.InvestmentID)
+	for _, holding := range []struct {
+		ticker   model.Ticker
+		quantity string
+	}{
+		{ticker: amd, quantity: "0.15"},
+		{ticker: intc, quantity: "1.2"},
+		{ticker: amat, quantity: "0.1"},
+	} {
+		qty, err := decimal.NewFromString(holding.quantity)
+		if err != nil {
+			panic(err)
+		}
+		testseed.CreateInvestmentHolding(db, testseed.InvestmentHoldingOpts{
+			VersionID: version.InvestmentHoldingsVersionID,
+			TickerID:  holding.ticker.TickerID,
+			Quantity:  qty,
+		})
+	}
 }
 
 func sortedSeedNames() []string {

--- a/frontend-v2/src/pages/Investments/InvestmentsPage.tsx
+++ b/frontend-v2/src/pages/Investments/InvestmentsPage.tsx
@@ -1,15 +1,18 @@
-import { useQuery } from '@tanstack/react-query';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { useState } from 'react';
 
+import { Button } from '@/components/ui/button';
 import { Card } from '@/components/ui/card';
-import { apiClient } from '@/lib/api';
+import { apiClient, isApiError } from '@/lib/api';
 import { formatCurrency, formatPercent } from '@/lib/format';
 import type { Investment } from '@/types/api';
+
+const investmentsQueryKey = ['investments'] as const;
 
 // Investments page - displays user's investment portfolio
 export function InvestmentsPage(): React.ReactNode {
   const { data, isLoading, isError, error } = useQuery({
-    queryKey: ['investments'],
+    queryKey: investmentsQueryKey,
     queryFn: () => apiClient.get<Investment[]>('/activeInvestments'),
   });
 
@@ -50,8 +53,26 @@ export function InvestmentsPage(): React.ReactNode {
 
 function InvestmentCard({ investment }: { investment: Investment }): React.ReactNode {
   const [expanded, setExpanded] = useState(false);
+  const [confirmingLiquidation, setConfirmingLiquidation] = useState(false);
+  const queryClient = useQueryClient();
   const profitLoss = investment.currentValue - investment.originalAmountDollars;
   const isProfit = profitLoss >= 0;
+  const liquidationRequested = investment.liquidationRequestedAt !== null;
+  const requestLiquidation = useMutation({
+    mutationFn: () =>
+      apiClient.post<{ success: boolean }>(
+        `/investments/${investment.investmentID}/request-liquidation`,
+      ),
+    onSuccess: async () => {
+      setConfirmingLiquidation(false);
+      await queryClient.invalidateQueries({ queryKey: investmentsQueryKey });
+    },
+  });
+  const requestError = requestLiquidation.error
+    ? isApiError(requestLiquidation.error)
+      ? requestLiquidation.error.message
+      : 'Failed to request liquidation'
+    : null;
 
   return (
     <Card className="flex flex-col">
@@ -186,9 +207,87 @@ function InvestmentCard({ investment }: { investment: Investment }): React.React
                 </div>
               </div>
             )}
+
+            {/* Liquidation */}
+            <div className="border-t border-border pt-4">
+              <h4 className="text-xs font-medium uppercase tracking-wider text-muted-foreground">
+                End Investment
+              </h4>
+              <div className="mt-3 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+                <p className="max-w-md text-xs leading-5 text-muted-foreground">
+                  Queue sell orders for all current holdings during the next rebalance.
+                </p>
+                <Button
+                  type="button"
+                  variant={liquidationRequested ? 'outline' : 'default'}
+                  size="sm"
+                  disabled={liquidationRequested || requestLiquidation.isPending}
+                  onClick={() => {
+                    requestLiquidation.reset();
+                    setConfirmingLiquidation(true);
+                  }}
+                  className="w-full sm:w-auto"
+                >
+                  {liquidationRequested
+                    ? 'Liquidation requested'
+                    : requestLiquidation.isPending
+                      ? 'Requesting...'
+                      : 'End investment'}
+                </Button>
+              </div>
+              {investment.liquidationRequestedAt && (
+                <p className="mt-2 text-xs text-muted-foreground">
+                  Requested {new Date(investment.liquidationRequestedAt).toLocaleString()}
+                </p>
+              )}
+              {requestError && <p className="mt-2 text-xs text-loss">{requestError}</p>}
+            </div>
           </div>
         )}
       </div>
+
+      {confirmingLiquidation && (
+        <div
+          className="fixed inset-0 z-50 flex items-center justify-center bg-background/80 px-4"
+          role="presentation"
+        >
+          <div
+            role="dialog"
+            aria-modal="true"
+            aria-labelledby={`liquidation-title-${investment.investmentID}`}
+            className="w-full max-w-md rounded-lg border border-border bg-card p-5"
+          >
+            <h3
+              id={`liquidation-title-${investment.investmentID}`}
+              className="text-base font-semibold text-foreground"
+            >
+              End investment?
+            </h3>
+            <p className="mt-2 text-sm leading-6 text-muted-foreground">
+              This will request liquidation and queue sell orders for the next rebalance. The
+              investment stays active until those sell orders complete.
+            </p>
+            {requestError && <p className="mt-3 text-sm text-loss">{requestError}</p>}
+            <div className="mt-5 flex flex-col-reverse gap-2 sm:flex-row sm:justify-end">
+              <Button
+                type="button"
+                variant="outline"
+                disabled={requestLiquidation.isPending}
+                onClick={() => setConfirmingLiquidation(false)}
+              >
+                Cancel
+              </Button>
+              <Button
+                type="button"
+                disabled={requestLiquidation.isPending}
+                onClick={() => requestLiquidation.mutate()}
+              >
+                {requestLiquidation.isPending ? 'Requesting...' : 'Confirm'}
+              </Button>
+            </div>
+          </div>
+        </div>
+      )}
     </Card>
   );
 }

--- a/frontend-v2/src/types/api.ts
+++ b/frontend-v2/src/types/api.ts
@@ -27,6 +27,7 @@ export interface Investment {
   investmentID: string;
   originalAmountDollars: number;
   startDate: string; // ISO-8601 date string
+  liquidationRequestedAt: string | null;
   strategy: InvestmentStrategy;
   holdings: Holding[];
   percentReturnFraction: number;

--- a/internal/service/investment.service.go
+++ b/internal/service/investment.service.go
@@ -167,13 +167,14 @@ func (h investmentServiceHandler) Add(ctx context.Context, userAccountID uuid.UU
 }
 
 type GetStatsResponse struct {
-	Holdings              []domain.Position
-	OriginalAmount        int32
-	StartDate             time.Time
-	PercentReturnFraction decimal.Decimal
-	CurrentValue          decimal.Decimal
-	CompletedTrades       []domain.FilledTrade
-	Strategy              model.Strategy
+	Holdings               []domain.Position
+	OriginalAmount         int32
+	StartDate              time.Time
+	LiquidationRequestedAt *time.Time
+	PercentReturnFraction  decimal.Decimal
+	CurrentValue           decimal.Decimal
+	CompletedTrades        []domain.FilledTrade
+	Strategy               model.Strategy
 }
 
 func (h investmentServiceHandler) GetStats(ctx context.Context, investmentID uuid.UUID) (*GetStatsResponse, error) {
@@ -232,13 +233,14 @@ func (h investmentServiceHandler) GetStats(ctx context.Context, investmentID uui
 	}
 
 	return &GetStatsResponse{
-		Holdings:              positions,
-		StartDate:             investment.StartDate,
-		CurrentValue:          totalValue,
-		PercentReturnFraction: returnFraction,
-		CompletedTrades:       completedTrades,
-		Strategy:              *strategy,
-		OriginalAmount:        investment.AmountDollars,
+		Holdings:               positions,
+		StartDate:              investment.StartDate,
+		LiquidationRequestedAt: investment.LiquidationRequestedAt,
+		CurrentValue:           totalValue,
+		PercentReturnFraction:  returnFraction,
+		CompletedTrades:        completedTrades,
+		Strategy:               *strategy,
+		OriginalAmount:         investment.AmountDollars,
 	}, nil
 }
 


### PR DESCRIPTION
## Summary
- add liquidationRequestedAt to the active investments API response and v2 API type
- add an expanded-card End Investment section with confirmation modal and disabled Liquidation requested state
- add seeded active/liquidating investment fixtures to cmd/test-api with test auth support for browser verification

## Verification
- npm run typecheck
- npm run lint
- npm run build
- go test ./api ./cmd/test-api ./internal/service ./internal/repository -count=1
- go test ./integration-tests -run TestInvestmentLiquidationHTTPFlow -count=1
- browser-verified /investments against cmd/test-api -seed active_investment: expand card, open modal, confirm request, disabled Liquidation requested state on desktop/mobile

Note: broad go test ./... is still not a good verification target after local browser setup because it walks generated local postgres-data/node_modules, and the existing rebalance integration test has a date expectation mismatch against the current clock.