### PR TITLE
Expose investment liquidation lifecycle

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -162,7 +162,8 @@ func (m ApiHandler) InitializeRouterEngine(ctx context.Context) *gin.Engine {
 	engine.GET("/savedStrategies", m.getSavedStrategies)
 	engine.POST("/investInStrategy", m.investInStrategy)
 	engine.POST("/investments/:investmentID/request-liquidation", m.requestLiquidation)
-	engine.GET("/activeInvestments", m.getInvestments)
+	engine.GET("/activeInvestments", m.getActiveInvestments)
+	engine.GET("/investments", m.getAllInvestments)
 	engine.GET("/publishedStrategies", m.getPublishedStrategies)
 
 	cron := engine.Group("/internal/cron")

--- a/api/get_investments.resolver.go
+++ b/api/get_investments.resolver.go
@@ -15,7 +15,9 @@ type GetInvestmentsResponse struct {
 	InvestmentID           uuid.UUID     `json:"investmentID"`
 	OriginalAmountDollars  int32         `json:"originalAmountDollars"`
 	StartDate              string        `json:"startDate"`
+	EndDate                *string       `json:"endDate"`
 	LiquidationRequestedAt *string       `json:"liquidationRequestedAt"`
+	Status                 string        `json:"status"`
 	Strategy               Strategy      `json:"strategy"`
 	Holdings               []Holdings    `json:"holdings"`
 	PercentReturnFraction  float64       `json:"percentReturnFraction"`
@@ -46,7 +48,15 @@ type Strategy struct {
 	RebalanceInterval string    `json:"rebalanceInterval"`
 }
 
-func (m ApiHandler) getInvestments(c *gin.Context) {
+func (m ApiHandler) getActiveInvestments(c *gin.Context) {
+	m.getInvestments(c, false)
+}
+
+func (m ApiHandler) getAllInvestments(c *gin.Context) {
+	m.getInvestments(c, true)
+}
+
+func (m ApiHandler) getInvestments(c *gin.Context, includeEnded bool) {
 	ginUserAccountID, ok := c.Get("userAccountID")
 	if !ok {
 		returnErrorJson(fmt.Errorf("must be logged in to view investments"), c)
@@ -67,6 +77,7 @@ func (m ApiHandler) getInvestments(c *gin.Context) {
 	investments, err := m.InvestmentRepository.List(repository.StrategyInvestmentListFilter{
 		UserAccountIDs: []uuid.UUID{userAccountID},
 		IncludePaused:  true,
+		IncludeEnded:   includeEnded,
 	})
 	if err != nil {
 		returnErrorJson(err, c)
@@ -115,12 +126,19 @@ func getInvestmentsResponseFromDomain(in map[uuid.UUID]service.GetStatsResponse)
 			formatted := stats.LiquidationRequestedAt.Format(time.RFC3339)
 			liquidationRequestedAt = &formatted
 		}
+		var endDate *string
+		if stats.EndDate != nil {
+			formatted := stats.EndDate.Format(time.DateOnly)
+			endDate = &formatted
+		}
 
 		out = append(out, GetInvestmentsResponse{
 			InvestmentID:           investmentID,
 			OriginalAmountDollars:  stats.OriginalAmount,
 			StartDate:              stats.StartDate.Format(time.DateOnly),
+			EndDate:                endDate,
 			LiquidationRequestedAt: liquidationRequestedAt,
+			Status:                 string(stats.Status),
 			Strategy: Strategy{
 				StrategyID:        stats.Strategy.StrategyID,
 				StrategyName:      stats.Strategy.StrategyName,

--- a/api/get_investments.resolver_test.go
+++ b/api/get_investments.resolver_test.go
@@ -17,10 +17,30 @@ func TestGetInvestmentsResponseFromDomainIncludesLiquidationRequestedAt(t *testi
 		investmentID: {
 			StartDate:              time.Date(2026, 4, 8, 0, 0, 0, 0, time.UTC),
 			LiquidationRequestedAt: &requestedAt,
+			Status:                 service.InvestmentStatusLiquidationRequested,
 		},
 	})
 
 	require.Len(t, out, 1)
 	require.NotNil(t, out[0].LiquidationRequestedAt)
 	require.Equal(t, "2026-07-14T15:30:00Z", *out[0].LiquidationRequestedAt)
+	require.Equal(t, "LIQUIDATION_REQUESTED", out[0].Status)
+}
+
+func TestGetInvestmentsResponseFromDomainIncludesLiquidationCompletion(t *testing.T) {
+	investmentID := uuid.New()
+	endedAt := time.Date(2026, 7, 15, 0, 0, 0, 0, time.UTC)
+
+	out := getInvestmentsResponseFromDomain(map[uuid.UUID]service.GetStatsResponse{
+		investmentID: {
+			StartDate: time.Date(2026, 4, 8, 0, 0, 0, 0, time.UTC),
+			EndDate:   &endedAt,
+			Status:    service.InvestmentStatusLiquidated,
+		},
+	})
+
+	require.Len(t, out, 1)
+	require.NotNil(t, out[0].EndDate)
+	require.Equal(t, "2026-07-15", *out[0].EndDate)
+	require.Equal(t, "LIQUIDATED", out[0].Status)
 }

--- a/integration-tests/liquidation_test.go
+++ b/integration-tests/liquidation_test.go
@@ -155,6 +155,11 @@ func TestInvestmentLiquidationHTTPFlow(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, requested.LiquidationRequestedAt)
 	requestedAt := *requested.LiquidationRequestedAt
+	allInvestments := []api.GetInvestmentsResponse{}
+	hitAuthenticatedEndpoint(t, server.URL, "/investments", http.MethodGet, user.UserAccountID, http.StatusOK, &allInvestments)
+	require.Len(t, allInvestments, 1)
+	require.Equal(t, "LIQUIDATION_REQUESTED", allInvestments[0].Status)
+	require.Nil(t, allInvestments[0].EndDate)
 
 	hitAuthenticatedEndpoint(t, server.URL, "/investments/"+investment.InvestmentID.String()+"/request-liquidation", http.MethodPost, user.UserAccountID, http.StatusAccepted, &response)
 	requestedAgain, err := investmentRepository.Get(investment.InvestmentID)
@@ -171,6 +176,10 @@ func TestInvestmentLiquidationHTTPFlow(t *testing.T) {
 	require.Equal(t, "GOOG", requests[1].Symbol)
 	require.Equal(t, alpaca.Sell, requests[1].Side)
 	require.Equal(t, decimal.NewFromFloat(0.25), requests[1].Quantity)
+	allInvestments = nil
+	hitAuthenticatedEndpoint(t, server.URL, "/investments", http.MethodGet, user.UserAccountID, http.StatusOK, &allInvestments)
+	require.Len(t, allInvestments, 1)
+	require.Equal(t, "LIQUIDATING", allInvestments[0].Status)
 
 	pending, err := investmentRepository.Get(investment.InvestmentID)
 	require.NoError(t, err)
@@ -193,6 +202,11 @@ func TestInvestmentLiquidationHTTPFlow(t *testing.T) {
 	active := []api.GetInvestmentsResponse{}
 	hitAuthenticatedEndpoint(t, server.URL, "/activeInvestments", http.MethodGet, user.UserAccountID, http.StatusOK, &active)
 	require.Empty(t, active)
+	allInvestments = nil
+	hitAuthenticatedEndpoint(t, server.URL, "/investments", http.MethodGet, user.UserAccountID, http.StatusOK, &allInvestments)
+	require.Len(t, allInvestments, 1)
+	require.Equal(t, "LIQUIDATED", allInvestments[0].Status)
+	require.NotNil(t, allInvestments[0].EndDate)
 
 	require.NoError(t, hitEndpoint(server.URL, "internal/cron/rebalance", http.MethodPost, map[string]string{}, &map[string]string{}))
 	require.Len(t, broker.placedRequests(), 2, "an ended investment must not create more orders")

--- a/internal/repository/investment.repository.go
+++ b/internal/repository/investment.repository.go
@@ -72,6 +72,7 @@ func (h investmentRepositoryHandler) Get(id uuid.UUID) (*model.Investment, error
 type StrategyInvestmentListFilter struct {
 	UserAccountIDs []uuid.UUID
 	IncludePaused  bool
+	IncludeEnded   bool
 }
 
 func (h investmentRepositoryHandler) List(filter StrategyInvestmentListFilter) ([]model.Investment, error) {
@@ -79,8 +80,9 @@ func (h investmentRepositoryHandler) List(filter StrategyInvestmentListFilter) (
 		SELECT(table.Investment.AllColumns).
 		ORDER_BY(table.Investment.CreatedAt.DESC())
 
-	whereClauses := []postgres.BoolExpression{
-		table.Investment.EndDate.IS_NULL(),
+	whereClauses := []postgres.BoolExpression{}
+	if !filter.IncludeEnded {
+		whereClauses = append(whereClauses, table.Investment.EndDate.IS_NULL())
 	}
 	if !filter.IncludePaused {
 		whereClauses = append(whereClauses, postgres.OR(
@@ -98,7 +100,9 @@ func (h investmentRepositoryHandler) List(filter StrategyInvestmentListFilter) (
 		)
 	}
 
-	query = query.WHERE(postgres.AND(whereClauses...))
+	if len(whereClauses) > 0 {
+		query = query.WHERE(postgres.AND(whereClauses...))
+	}
 
 	result := []model.Investment{}
 	err := query.Query(h.Db, &result)

--- a/internal/service/investment.service.go
+++ b/internal/service/investment.service.go
@@ -170,11 +170,38 @@ type GetStatsResponse struct {
 	Holdings               []domain.Position
 	OriginalAmount         int32
 	StartDate              time.Time
+	EndDate                *time.Time
 	LiquidationRequestedAt *time.Time
+	Status                 InvestmentStatus
 	PercentReturnFraction  decimal.Decimal
 	CurrentValue           decimal.Decimal
 	CompletedTrades        []domain.FilledTrade
 	Strategy               model.Strategy
+}
+
+type InvestmentStatus string
+
+const (
+	InvestmentStatusActive               InvestmentStatus = "ACTIVE"
+	InvestmentStatusLiquidationRequested InvestmentStatus = "LIQUIDATION_REQUESTED"
+	InvestmentStatusLiquidating          InvestmentStatus = "LIQUIDATING"
+	InvestmentStatusLiquidated           InvestmentStatus = "LIQUIDATED"
+)
+
+func getInvestmentStatus(investment model.Investment, trades []*model.InvestmentTradeStatus) InvestmentStatus {
+	if investment.EndDate != nil {
+		return InvestmentStatusLiquidated
+	}
+	if investment.LiquidationRequestedAt == nil {
+		return InvestmentStatusActive
+	}
+	for _, trade := range trades {
+		if trade.Side != nil && *trade.Side == model.TradeOrderSide_Sell &&
+			trade.Status != nil && *trade.Status == model.TradeOrderStatus_Pending {
+			return InvestmentStatusLiquidating
+		}
+	}
+	return InvestmentStatusLiquidationRequested
 }
 
 func (h investmentServiceHandler) GetStats(ctx context.Context, investmentID uuid.UUID) (*GetStatsResponse, error) {
@@ -235,7 +262,9 @@ func (h investmentServiceHandler) GetStats(ctx context.Context, investmentID uui
 	return &GetStatsResponse{
 		Holdings:               positions,
 		StartDate:              investment.StartDate,
+		EndDate:                investment.EndDate,
 		LiquidationRequestedAt: investment.LiquidationRequestedAt,
+		Status:                 getInvestmentStatus(*investment, allTradesWithStatus),
 		CurrentValue:           totalValue,
 		PercentReturnFraction:  returnFraction,
 		CompletedTrades:        completedTrades,

--- a/internal/service/investment.service_test.go
+++ b/internal/service/investment.service_test.go
@@ -215,6 +215,49 @@ func TestInvestmentServiceRequestLiquidation(t *testing.T) {
 	require.NoError(t, handler.RequestLiquidation(context.Background(), userAccountID, investmentID))
 }
 
+func TestGetInvestmentStatus(t *testing.T) {
+	now := time.Now().UTC()
+	sell := model.TradeOrderSide_Sell
+	pending := model.TradeOrderStatus_Pending
+
+	tests := []struct {
+		name       string
+		investment model.Investment
+		trades     []*model.InvestmentTradeStatus
+		want       InvestmentStatus
+	}{
+		{name: "active", want: InvestmentStatusActive},
+		{
+			name:       "liquidation requested",
+			investment: model.Investment{LiquidationRequestedAt: &now},
+			want:       InvestmentStatusLiquidationRequested,
+		},
+		{
+			name:       "sell orders pending",
+			investment: model.Investment{LiquidationRequestedAt: &now},
+			trades: []*model.InvestmentTradeStatus{{
+				Side:   &sell,
+				Status: &pending,
+			}},
+			want: InvestmentStatusLiquidating,
+		},
+		{
+			name: "liquidated",
+			investment: model.Investment{
+				LiquidationRequestedAt: &now,
+				EndDate:                &now,
+			},
+			want: InvestmentStatusLiquidated,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, getInvestmentStatus(tt.investment, tt.trades))
+		})
+	}
+}
+
 func TestGetTargetPortfolioForLiquidation(t *testing.T) {
 	requestedAt := time.Now()
 	portfolioValue := decimal.NewFromFloat(123.45)


### PR DESCRIPTION
## Summary
- add an authenticated `GET /investments` endpoint that includes active and ended investments
- expose `status` and `endDate` while preserving `/activeInvestments` compatibility
- derive `ACTIVE`, `LIQUIDATION_REQUESTED`, `LIQUIDATING`, and `LIQUIDATED` from existing investment and trade data
- extend the HTTP/database liquidation test through request, pending broker orders, fills, and history retention

## Design
Completed investments remain soft-ended through the existing `investment.end_date`; no archive table or migration is introduced. The frontend can treat ended records from `/investments` as its Past Investments section.

## Verification
- `go test ./api ./internal/repository ./internal/service -count=1`
- `go test ./integration-tests -run TestInvestmentLiquidationHTTPFlow -count=1`
- `ALPHA_ENV=test go test ./... -count=1`
- `git diff --check`